### PR TITLE
Handle expired request

### DIFF
--- a/pyeudiw/satosa/backend.py
+++ b/pyeudiw/satosa/backend.py
@@ -408,7 +408,7 @@ class OpenID4VPBackend(BackendModule, BackendTrust, BackendDPoP):
                 err=f"{e.__class__.__name__}: {e}",
                 err_code="400"
             )
-        
+
         if stored_session["finalized"]:
             _msg = f"Session already finalized"
             return self.handle_error(
@@ -418,7 +418,7 @@ class OpenID4VPBackend(BackendModule, BackendTrust, BackendDPoP):
                 err=_msg,
                 err_code="400"
             )
-        
+
         # TODO: handle vp token ops exceptions
         try:
             vpt.load_nonce(stored_session['nonce'])
@@ -477,16 +477,17 @@ class OpenID4VPBackend(BackendModule, BackendTrust, BackendDPoP):
 
             # the trust is established to the credential issuer, then we can get the disclosed user attributes
             # TODO - what if the credential is different from sd-jwt? -> generalyze within Vp class
-            
+
             try:
                 vp.verify_sdjwt(
-                    issuer_jwks_by_kid={i['kid']: i for i in vp.credential_jwks}
+                    issuer_jwks_by_kid={
+                        i['kid']: i for i in vp.credential_jwks}
                 )
             except Exception as e:
                 return self.handle_error(
-                    context=context, 
-                    message="invalid_request", 
-                    troubleshoot=f"VP SD-JWT validation error: {e}", 
+                    context=context,
+                    message="invalid_request",
+                    troubleshoot=f"VP SD-JWT validation error: {e}",
                     err_code="400"
                 )
 
@@ -746,7 +747,7 @@ class OpenID4VPBackend(BackendModule, BackendTrust, BackendDPoP):
                 troubleshoot="session not found or invalid",
                 err_code="400"
             )
-        
+
         _now = iat_now()
         _exp = finalized_session['request_object']['exp']
         if _exp < _now:
@@ -756,7 +757,7 @@ class OpenID4VPBackend(BackendModule, BackendTrust, BackendDPoP):
                 troubleshoot=f"session expired, request object exp is {_exp} while now is {_now}",
                 err_code="400"
             )
-        
+
         internal_response = InternalData()
         resp = internal_response.from_dict(
             finalized_session['internal_response']

--- a/pyeudiw/satosa/backend.py
+++ b/pyeudiw/satosa/backend.py
@@ -810,7 +810,16 @@ class OpenID4VPBackend(BackendModule, BackendTrust, BackendDPoP):
                 err_code="401"
             )
 
-        # TODO: if the request is expired -> return 403
+        request_object = session.get("request_object", None)
+        if request_object:
+            if request_object["exp"] >= iat_now():
+                return self.handle_error(
+                    context=context,
+                    message="expired",
+                    troubleshoot=f"Request object expired",
+                    err_code="403"
+                )
+
         if session["finalized"]:
             #  return Redirect(
             #      self.registered_get_response_endpoint

--- a/pyeudiw/sd_jwt/__init__.py
+++ b/pyeudiw/sd_jwt/__init__.py
@@ -159,9 +159,9 @@ def _cb_get_issuer_key(issuer: str, settings: dict, adapted_keys: dict, *args, *
 
 
 def verify_sd_jwt(
-    sd_jwt_presentation: str, 
-    issuer_key: JWK, 
-    holder_key: JWK, 
+    sd_jwt_presentation: str,
+    issuer_key: JWK,
+    holder_key: JWK,
     settings: dict = {'key_binding': True}
 ) -> dict:
 
@@ -175,18 +175,18 @@ def verify_sd_jwt(
         "holder_key": jwcrypto.jwk.JWK(**holder_key.as_dict()),
         "issuer_public_key": jwcrypto.jwk.JWK(**issuer_key.as_dict())
     }
-    
+
     serialization_format = "compact"
     sdjwt_at_verifier = SDJWTVerifier(
         sd_jwt_presentation,
-        cb_get_issuer_key = (
+        cb_get_issuer_key=(
             lambda x, unverified_header_parameters: _cb_get_issuer_key(
                 x, settings, adapted_keys, **unverified_header_parameters
             )
         ),
-        expected_aud = None,
-        expected_nonce = None,
-        serialization_format = serialization_format,
+        expected_aud=None,
+        expected_nonce=None,
+        serialization_format=serialization_format,
     )
 
     return sdjwt_at_verifier.get_verified_payload()


### PR DESCRIPTION
Status endpoint checks if a request object exists.
If it exists, the `exp` field from the object is evaluated with the current timestamp.

Closes #139