### PR TITLE
fix: introduce constraint on cryptography version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ setup(
         "cryptojwt>=1.8.2,<1.9",
         "pydantic>=2.0,<2.2",
         "pyqrcode>=1.2,<1.3",
-        "pem>=23.1,<23.2"
+        "pem>=23.1,<23.2",
+        "cryptography<42.0.0"
     ],
     extra_require={
         "satosa": [


### PR DESCRIPTION
Introduce an upperbound constraint on the package `cryptography` to resolve the problems caused by the latest release `42.0.0`.

Additional info on the breaking changes and the errors can be found [here](https://github.com/salvatorelaiso/eudi-wallet-it-python/actions/runs/7630085474/job/20784982336).

Closes #234