### PR TITLE
feat: wallet scheme references from eudiw to haip

### DIFF
--- a/example/satosa/integration_test/settings.py
+++ b/example/satosa/integration_test/settings.py
@@ -49,7 +49,7 @@ WALLET_INSTANCE_ATTESTATION = {
     {
         "jwk": leaf_wallet_jwk.serialize()
     },
-    "authorization_endpoint": "eudiw:",
+    "authorization_endpoint": "haip:",
     "response_types_supported": [
         "vp_token"
     ],

--- a/example/satosa/pyeudiw_backend.yaml
+++ b/example/satosa/pyeudiw_backend.yaml
@@ -52,7 +52,7 @@ config:
         - ES512
     
   authorization:
-    url_scheme: eudiw
+    url_scheme: haip
     scopes: 
     - pid-sd-jwt:unique_id+given_name+family_name
     default_acr_value: https://www.spid.gov.it/SpidL2

--- a/pyeudiw/tests/oauth2/test_dpop.py
+++ b/pyeudiw/tests/oauth2/test_dpop.py
@@ -25,7 +25,7 @@ WALLET_INSTANCE_ATTESTATION = {
     {
         "jwk": PUBLIC_JWK
     },
-    "authorization_endpoint": "eudiw:",
+    "authorization_endpoint": "haip:",
     "response_types_supported": [
         "vp_token"
     ],

--- a/pyeudiw/tests/openid4vp/schemas/test_wallet_instance_attestation.py
+++ b/pyeudiw/tests/openid4vp/schemas/test_wallet_instance_attestation.py
@@ -47,7 +47,7 @@ WALLET_INSTANCE_ATTESTATION = {
                 "x5t": "NjVBRjY5MDlCMUIwNzU4RTA2QzZFMDQ4QzQ2MDAyQjVDNjk1RTM2Qg"
             }
         },
-        "authorization_endpoint": "eudiw:",
+        "authorization_endpoint": "haip:",
         "response_types_supported": [
             "vp_token"
         ],

--- a/pyeudiw/tests/satosa/test_backend.py
+++ b/pyeudiw/tests/satosa/test_backend.py
@@ -140,7 +140,7 @@ class TestOpenID4VPBackend:
             pre_request_endpoint.message, encoding='utf-8', errors='replace')
         parsed = urllib.parse.urlparse(unquoted)
 
-        assert parsed.scheme == "eudiw"
+        assert parsed.scheme == CONFIG['authorization']['url_scheme']
         assert parsed.netloc == "authorize"
         assert parsed.path == ""
         assert parsed.query

--- a/pyeudiw/tests/settings.py
+++ b/pyeudiw/tests/settings.py
@@ -44,7 +44,7 @@ CONFIG = {
         "default_exp": 6
     },
     "authorization": {
-        "url_scheme": "eudiw",  # eudiw://
+        "url_scheme": "haip",  # haip://
         "scopes": ["pid-sd-jwt:unique_id+given_name+family_name"],
         "default_acr_value": "https://www.spid.gov.it/SpidL2",
         "expiration_time": 5,  # minutes
@@ -379,7 +379,7 @@ WALLET_INSTANCE_ATTESTATION = {
     {
         "jwk": PUBLIC_JWK
     },
-    "authorization_endpoint": "eudiw:",
+    "authorization_endpoint": "haip:",
     "response_types_supported": [
         "vp_token"
     ],


### PR DESCRIPTION
Wallet instance invocation used to rely on a custom scheme called `eudiw://`, but according to interoperability specs [OpenID4VC High Assurance Interoperability Profile with SD-JWT VC - draft 00](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-sd-jwt-vc-1_0-00.html), the scheme `haip://` should be preferred.

This pull requests proposes to fill this gap in default satosa example settings, integration tests and unit tests

