### PR TITLE
fix: compatibility with sd-jwt-python v0.10.4

### DIFF
--- a/pyeudiw/sd_jwt/__init__.py
+++ b/pyeudiw/sd_jwt/__init__.py
@@ -63,10 +63,11 @@ class TrustChainSDJWTIssuer(SDJWTIssuer):
 
         self.additional_headers = additional_headers
         sign_alg = sign_alg if sign_alg else DEFAULT_SIG_KTY_MAP[issuer_key.kty]
+        issuer_keys = [issuer_key]
 
         super().__init__(
             user_claims,
-            issuer_key,
+            issuer_keys,
             holder_key,
             sign_alg,
             add_decoy_claims,
@@ -88,7 +89,7 @@ class TrustChainSDJWTIssuer(SDJWTIssuer):
 
         # _protected_headers['kid'] = self._issuer_key['kid']
         self.sd_jwt.add_signature(
-            self._issuer_key,
+            self._issuer_keys[0],
             alg=self._sign_alg,
             protected=dumps(_protected_headers),
         )


### PR DESCRIPTION
This pull request is aimed at fixing #249 

Data structure of pyeudi sdk object is unchanged (still accepts only one JWK) but is traslated to a list of one element when invoking parent constructor.