### PR TITLE
feat: cross device integration test

### DIFF
--- a/example/satosa/integration_test/commons.py
+++ b/example/satosa/integration_test/commons.py
@@ -1,0 +1,211 @@
+import base64
+import datetime
+import requests
+import uuid
+from typing import Any, Literal
+from bs4 import BeautifulSoup
+from sd_jwt.holder import SDJWTHolder
+
+from pyeudiw.jwk import JWK
+from pyeudiw.jwt import DEFAULT_SIG_KTY_MAP, JWEHelper, JWSHelper
+from pyeudiw.jwt.utils import decode_jwt_payload
+from pyeudiw.presentation_exchange.schemas.oid4vc_presentation_definition import PresentationDefinition
+from pyeudiw.sd_jwt import (
+    # _adapt_keys,
+    import_ec,
+    issue_sd_jwt,
+    load_specification_from_yaml_string
+)
+from pyeudiw.storage.db_engine import DBEngine
+from pyeudiw.tests.federation.base import (
+    EXP,
+    ta_ec,
+    ta_ec_signed,
+    leaf_cred,
+    leaf_cred_jwk,
+    leaf_cred_jwk_prot,
+    leaf_cred_signed,
+    leaf_wallet,
+    leaf_wallet_jwk,
+    leaf_wallet_signed,
+    trust_chain_issuer
+)
+from pyeudiw.tools.utils import iat_now, exp_from_now
+
+from saml2_sp import IDP_BASEURL
+from settings import (
+    CONFIG_DB,
+    RP_EID,
+    its_trust_chain
+)
+
+CREDENTIAL_ISSUER_JWK = JWK(leaf_cred_jwk_prot.serialize(private=True))
+ISSUER_CONF = {
+    "sd_specification": """
+        user_claims:
+            !sd unique_id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+            !sd given_name: "Mario"
+            !sd family_name: "Rossi"
+            !sd birthdate: "1980-01-10"
+            !sd place_of_birth:
+                country: "IT"
+                locality: "Rome"
+            !sd tax_id_code: "TINIT-XXXXXXXXXXXXXXXX"
+
+        holder_disclosed_claims:
+            { "given_name": "Mario", "family_name": "Rossi", "place_of_birth": {country: "IT", locality: "Rome"}, "tax_id_code": "TINIT-XXXXXXXXXXXXXXXX" }
+
+        key_binding: True
+    """,
+    "issuer": leaf_cred['sub'],
+    "default_exp": 1024
+}
+ISSUER_PRIVATE_JWK = JWK(leaf_cred_jwk.serialize(private=True))
+WALLET_PRIVATE_JWK = JWK(leaf_wallet_jwk.serialize(private=True))
+WALLET_PUBLIC_JWK = JWK(leaf_wallet_jwk.serialize())
+
+
+def setup_test_db_engine() -> DBEngine:
+    return DBEngine(CONFIG_DB)
+
+
+def apply_trust_settings(db_engine_inst: DBEngine) -> DBEngine:
+    db_engine_inst.add_trust_anchor(
+        entity_id=ta_ec['iss'],
+        entity_configuration=ta_ec_signed,
+        exp=EXP
+    )
+
+    db_engine_inst.add_or_update_trust_attestation(
+        entity_id=RP_EID,
+        attestation=its_trust_chain,
+        exp=datetime.datetime.now().isoformat()
+    )
+
+    db_engine_inst.add_or_update_trust_attestation(
+        entity_id=leaf_wallet['iss'],
+        attestation=leaf_wallet_signed,
+        exp=datetime.datetime.now().isoformat()
+    )
+
+    db_engine_inst.add_or_update_trust_attestation(
+        entity_id=leaf_cred['iss'],
+        attestation=leaf_cred_signed,
+        exp=datetime.datetime.now().isoformat()
+    )
+    return db_engine_inst
+
+
+def create_issuer_test_data() -> dict[Literal["jws"] | Literal["issuance"], str]:
+    # create a SD-JWT signed by a trusted credential issuer
+    settings = ISSUER_CONF
+    settings['issuer'] = leaf_cred['iss']
+    settings['default_exp'] = 33
+    sd_specification = load_specification_from_yaml_string(
+        settings["sd_specification"]
+    )
+
+    issued_jwt = issue_sd_jwt(
+        sd_specification,
+        settings,
+        CREDENTIAL_ISSUER_JWK,
+        WALLET_PUBLIC_JWK,
+        trust_chain=trust_chain_issuer
+    )
+    return issued_jwt
+
+
+def create_holder_test_data(issued_jwt: dict[Literal["jws"] | Literal["issuance"], str], request_nonce: str) -> str:
+    settings = ISSUER_CONF
+    sd_specification = load_specification_from_yaml_string(
+        settings["sd_specification"]
+    )
+
+    sdjwt_at_holder = SDJWTHolder(
+        issued_jwt["issuance"],
+        serialization_format="compact",
+    )
+    sdjwt_at_holder.create_presentation(
+        claims_to_disclose={
+            'tax_id_code': "TIN-that",
+            'given_name': 'Raffaello',
+            'family_name': 'Mascetti'
+        },
+        nonce=str(uuid.uuid4()),
+        aud=str(uuid.uuid4()),
+        sign_alg=DEFAULT_SIG_KTY_MAP[WALLET_PRIVATE_JWK.key.kty],
+        holder_key=(
+            import_ec(
+                WALLET_PRIVATE_JWK.key.priv_key,
+                kid=WALLET_PRIVATE_JWK.kid
+            )
+            if sd_specification.get("key_binding", False)
+            else None
+        )
+    )
+
+    data = {
+        "iss": "https://wallet-provider.example.org/instance/vbeXJksM45xphtANnCiG6mCyuU4jfGNzopGuKvogg9c",
+        "jti": str(uuid.uuid4()),
+        "aud": "https://relying-party.example.org/callback",
+        "iat": iat_now(),
+        "exp": exp_from_now(minutes=5),
+        "nonce": request_nonce,
+        "vp": sdjwt_at_holder.sd_jwt_presentation,
+    }
+
+    vp_token = JWSHelper(WALLET_PRIVATE_JWK).sign(
+        data,
+        protected={"typ": "JWT"}
+    )
+    return vp_token
+
+
+def create_authorize_response(vp_token: str, state: str, nonce: str, response_uri: str) -> str:
+    # take relevant information from RP's entity configuration
+    client = requests.Session()
+    rp_ec_jwt = client.get(
+        f'{IDP_BASEURL}/OpenID4VP/.well-known/openid-federation',
+        verify=False
+    ).content.decode()
+    rp_ec = decode_jwt_payload(rp_ec_jwt)
+
+    presentation_definition = rp_ec["metadata"]["wallet_relying_party"]["presentation_definition"]
+    PresentationDefinition(**presentation_definition)
+    assert response_uri == rp_ec["metadata"]['wallet_relying_party']["response_uris_supported"][0]
+
+    response = {
+        "state": state,
+        "nonce": nonce,
+        "vp_token": vp_token,
+        "presentation_submission": {
+            "definition_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+            "id": "04a98be3-7fb0-4cf5-af9a-31579c8b0e7d",
+            "descriptor_map": [
+                {
+                    "id": "pid-sd-jwt:unique_id+given_name+family_name",
+                    "path": "$.vp_token.verified_claims.claims._sd[0]",
+                    "format": "vc+sd-jwt"
+                }
+            ],
+            "aud": response_uri
+        }
+    }
+    encrypted_response = JWEHelper(
+        # RSA (EC is not fully supported todate)
+        JWK(rp_ec["metadata"]['wallet_relying_party']['jwks']['keys'][1])
+    ).encrypt(response)
+    return encrypted_response
+
+
+def extract_saml_attributes(saml_response: str) -> set[Any]:
+    soup = BeautifulSoup(saml_response, features="lxml")
+    form = soup.find("form")
+    assert "/saml2" in form["action"]
+    input_tag = soup.find("input")
+    assert input_tag["name"] == "SAMLResponse"
+
+    lowered = base64.b64decode(input_tag["value"]).lower()
+    value = BeautifulSoup(lowered, features="xml")
+    attributes = value.find_all("saml:attribute")
+    return attributes

--- a/example/satosa/integration_test/cross_device_integration_test.py
+++ b/example/satosa/integration_test/cross_device_integration_test.py
@@ -152,7 +152,7 @@ expected = {
     # https://oidref.com/2.5.4.4
     "urn:oid:2.5.4.4": ISSUER_CONF['sd_specification'].split('!sd family_name:')[1].split('"')[1]
 }
-breakpoint()
+
 for attribute in attributes:
     name = attribute["name"]
     value = attribute.contents[0].contents[0]

--- a/example/satosa/integration_test/cross_device_integration_test.py
+++ b/example/satosa/integration_test/cross_device_integration_test.py
@@ -1,0 +1,163 @@
+import urllib.parse
+import requests
+import urllib
+from bs4 import BeautifulSoup
+
+from pyeudiw.jwt.utils import decode_jwt_payload
+
+from commons import (
+    ISSUER_CONF,
+    apply_trust_settings,
+    create_authorize_response,
+    create_holder_test_data,
+    create_issuer_test_data,
+    extract_saml_attributes,
+    setup_test_db_engine,
+)
+from saml2_sp import saml2_request
+from settings import TIMEOUT_S
+
+db_engine_inst = setup_test_db_engine()
+db_engine_inst = apply_trust_settings(db_engine_inst)
+
+headers_browser = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36"
+}
+
+
+def _verify_status(status_uri: str, expected_code: int):
+    status_check = http_user_agent.get(
+        status_uri,
+        verify=False,
+        timeout=TIMEOUT_S
+    )
+    assert status_check.status_code == expected_code
+
+
+def _extract_request_uri(bs: BeautifulSoup) -> str:
+    # TODO: find a better approach
+    qrcode_element = list(bs.find(id="content-qrcode-payload").children)[1]
+    qrcode_text = qrcode_element.get('contents')
+    request_uri = urllib.parse.parse_qs(qrcode_text)['request_uri'][0]
+    return request_uri
+
+
+def _extract_status_uri(bs: BeautifulSoup) -> str:
+    # TODO: find a better approach
+    qrcode_script_element: str = bs.find_all('script')[-1].string
+    pattern = 'endpointSatosa = "'
+    end_pattern = '";'
+    start = qrcode_script_element.find(pattern)
+    if start == -1:
+        raise ValueError(f"unable to find pattern '{pattern}'")
+    end = qrcode_script_element[start+len(pattern):].find(end_pattern)
+    if end == -1:
+        raise ValueError(f"unable to find pattern '{end}'")
+    status_path = qrcode_script_element[start+len(pattern):start+len(pattern)+end]
+
+    id_pattern = 'let data = {"id": "'
+    start = qrcode_script_element.find(id_pattern)
+    if start == -1:
+        raise ValueError(f"unable to find pattern '{id_pattern}'")
+    end_id_pattern = '"};'
+    end = qrcode_script_element[start+len(id_pattern):].find(end_id_pattern)
+    if end == -1:
+        raise ValueError(f"unable to find pattern '{end_id_pattern}'")
+    resource_id = qrcode_script_element[start+len(id_pattern):start+len(id_pattern)+end]
+
+    return f"{status_path}?id={resource_id}"
+
+
+# initialize the user-agent(s)
+http_user_agent = requests.Session()
+wallet_user_agent = requests.Session()
+
+initiating_saml_request_uri = f"{saml2_request['headers'][0][1]}&idp_hinting=wallet"
+request_uri = ""
+authn_response = http_user_agent.get(
+    url=initiating_saml_request_uri,
+    verify=False,
+    headers=headers_browser,
+    timeout=TIMEOUT_S
+)
+
+
+# Extract request URI and status endpoint by parsing the response page
+qrcode_page = BeautifulSoup(authn_response.content.decode(), features="html.parser")
+request_uri = _extract_request_uri(qrcode_page)
+status_uri = _extract_status_uri(qrcode_page)
+
+# Wallet has not interacted yet: verify that status is 201
+_verify_status(status_uri, expected_code=201)
+
+sign_request_obj = wallet_user_agent.get(
+    request_uri,
+    verify=False,
+    timeout=TIMEOUT_S)
+
+request_object_claims = decode_jwt_payload(sign_request_obj.json()['response'])
+response_uri = request_object_claims['response_uri']
+
+# Wallet obtained the Request Object; verify that status is 202
+_verify_status(status_uri, expected_code=202)
+
+# Provide an authentication response
+verifiable_credential = create_issuer_test_data()
+verifiable_presentations = create_holder_test_data(
+    verifiable_credential,
+    request_object_claims['nonce']
+)
+wallet_response_data = create_authorize_response(
+    verifiable_presentations,
+    request_object_claims["state"],
+    request_object_claims["nonce"],
+    response_uri
+)
+
+authz_response_feedback = wallet_user_agent.post(
+    response_uri,
+    verify=False,
+    data={'response': wallet_response_data},
+    timeout=TIMEOUT_S
+)
+
+assert authz_response_feedback.status_code == 200
+assert authz_response_feedback.json().get("redirect_uri", None) is None
+
+status_check = http_user_agent.get(
+    status_uri,
+    verify=False,
+    timeout=TIMEOUT_S
+)
+assert status_check.status_code == 200
+assert status_check.json().get("redirect_uri", None) is not None
+
+callback_uri = status_check.json().get("redirect_uri", None)
+satosa_authn_response = http_user_agent.get(
+    callback_uri,
+    verify=False,
+    timeout=TIMEOUT_S
+)
+
+assert 'SAMLResponse' in satosa_authn_response.content.decode()
+print(satosa_authn_response.content.decode())
+
+attributes = extract_saml_attributes(satosa_authn_response.content.decode())
+# expect to have a non-empty list of attributes
+assert attributes
+
+expected = {
+    # https://oidref.com/2.5.4.42
+    "urn:oid:2.5.4.42": ISSUER_CONF['sd_specification'].split('!sd given_name:')[1].split('"')[1],
+    # https://oidref.com/2.5.4.4
+    "urn:oid:2.5.4.4": ISSUER_CONF['sd_specification'].split('!sd family_name:')[1].split('"')[1]
+}
+breakpoint()
+for attribute in attributes:
+    name = attribute["name"]
+    value = attribute.contents[0].contents[0]
+    expected_value = expected.get(name, None)
+    if expected_value:
+        assert value == expected_value.lower()
+
+print('TEST PASSED')

--- a/example/satosa/integration_test/cross_device_integration_test.py
+++ b/example/satosa/integration_test/cross_device_integration_test.py
@@ -36,7 +36,7 @@ def _verify_status(status_uri: str, expected_code: int):
 
 
 def _extract_request_uri(bs: BeautifulSoup) -> str:
-    # TODO: find a better approach
+    # Request URI is extracted by parsing the QR code in the response page
     qrcode_element = list(bs.find(id="content-qrcode-payload").children)[1]
     qrcode_text = qrcode_element.get('contents')
     request_uri = urllib.parse.parse_qs(qrcode_text)['request_uri'][0]
@@ -44,6 +44,9 @@ def _extract_request_uri(bs: BeautifulSoup) -> str:
 
 
 def _extract_status_uri(bs: BeautifulSoup) -> str:
+    # Status uri is extracted by parsing a matching regexp in the <script> portion of the HTML.
+    # This funciton is somewhat unstable as it supposes that "qr_code.html" has certain properties
+    #  which might not be true.
     qrcode_script_element: str = bs.find_all('script')[-1].string
     qrcode_script_element_formatted = [item.strip() for item in qrcode_script_element.splitlines()]
     qrcode_script_element_formatted = str.join("", qrcode_script_element_formatted)
@@ -119,6 +122,7 @@ assert status_check.status_code == 200
 assert status_check.json().get("redirect_uri", None) is not None
 
 callback_uri = status_check.json().get("redirect_uri", None)
+# TODO: this test does not check that the login page is properly updated with a login button linkint to the redirect uri
 satosa_authn_response = http_user_agent.get(
     callback_uri,
     verify=False,

--- a/example/satosa/integration_test/settings.py
+++ b/example/satosa/integration_test/settings.py
@@ -11,6 +11,7 @@ from pyeudiw.tests.federation.base import (
 
 from pyeudiw.tools.utils import iat_now, exp_from_now
 
+TIMEOUT_S = 4
 
 RP_EID = "https://localhost/OpenID4VP"
 

--- a/example/satosa/templates/qr_code.html
+++ b/example/satosa/templates/qr_code.html
@@ -96,7 +96,7 @@
         changeQrCodeImg(connectedImg);
         $('#content-qrcode-info').html(`
             <div id="content-function" class="text-center button-container mt-2">
-                <button href="${data.response_url}" 
+                <button href="${data.response_uri}" 
                     class="btn btn-primary" 
                     aria-haspopup="false" 
                     aria-expanded="false" 

--- a/example/satosa/templates/qr_code.html
+++ b/example/satosa/templates/qr_code.html
@@ -183,9 +183,7 @@
 
     function QRcodeScanCheck() {
       let endpointSatosa = "{{ status_endpoint }}";
-      let data = {
-        "id": "{{ state }}", 
-      };
+      let data = {"id": "{{ state }}"};
 
       let ajaxRequest = $.ajax({
         type: 'GET',

--- a/pyeudiw/satosa/default/openid4vp_backend.py
+++ b/pyeudiw/satosa/default/openid4vp_backend.py
@@ -219,6 +219,8 @@ class OpenID4VPBackend(OpenID4VPBackendInterface, BackendTrust):
                 "qrcode_size": self.config["qrcode"]["size"],
                 "qrcode_logo_path": self.config["qrcode"]["logo_path"],
                 "qrcode_expiration_time": self.config["qrcode"]["expiration_time"],
+                "qrcode_size": self.config["qrcode"]["size"],
+                "qrcode_logo_path": self.config["qrcode"]["logo_path"],
                 "state": state,
                 "status_endpoint": self.absolute_status_url
             }

--- a/pyeudiw/satosa/default/openid4vp_backend.py
+++ b/pyeudiw/satosa/default/openid4vp_backend.py
@@ -219,8 +219,6 @@ class OpenID4VPBackend(OpenID4VPBackendInterface, BackendTrust):
                 "qrcode_size": self.config["qrcode"]["size"],
                 "qrcode_logo_path": self.config["qrcode"]["logo_path"],
                 "qrcode_expiration_time": self.config["qrcode"]["expiration_time"],
-                "qrcode_size": self.config["qrcode"]["size"],
-                "qrcode_logo_path": self.config["qrcode"]["logo_path"],
                 "state": state,
                 "status_endpoint": self.absolute_status_url
             }


### PR DESCRIPTION
This includes an initial implementation of cross device test, which closes #247 

This is a brief description of the proposed solution:
1. overall approach is similar to same device test
2. cookies and responses are updated to reflect the expectations of the cross device flow
3. after each authentication step in the flow, a second `request.Session` check(s) that the status endpoint yields the expected status code and message

Step 3 is non trivial as it requires obtaining somehow the status endpoint and its query parameters. This is done by parsing the Qr code page (pre authn endpoint), which is, frankly put, bad design... but I can't think of a better solution. Alternatives and proposals are welcomed
https://github.com/Zicchio/eudi-wallet-it-python/blob/bcd4593cf69070a649ba8573c407bc111a6e7628/example/satosa/integration_test/cross_device_integration_test.py#L46-L57

This is NOT in scope of this PR:
 1. unified design/code for both tests; a minor refactoring that involves the same device flow should follow this PR; this was not done here in order to minimize possible conflicts with other concurrent PRs that are validated with the same device flow (paraphrasing: by design there are no changes to https://github.com/Zicchio/eudi-wallet-it-python/blob/bcd4593cf69070a649ba8573c407bc111a6e7628/example/satosa/integration_test/main.py).
 2. possible invocation with an automated testing tool
 3. integration of the test in the CI pippeline (afaik same device flow is also not involved in the CI pipeline)