### PR TITLE
fix: optional direct trust httpc params

### DIFF
--- a/pyeudiw/tests/trust/default/test_direct_trust.py
+++ b/pyeudiw/tests/trust/default/test_direct_trust.py
@@ -1,6 +1,6 @@
 import unittest.mock
 
-from pyeudiw.trust.default import DEFAULT_DIRECT_TRUST_PARAMS
+from pyeudiw.trust.default import DEFAULT_DIRECT_TRUST_SD_JWC_VC_PARAMS
 from pyeudiw.trust.default.direct_trust_sd_jwt_vc import DirectTrustSdJwtVc
 
 from pyeudiw.tests.trust.default.settings import issuer, jwt_vc_issuer_endpoint_response
@@ -11,7 +11,7 @@ def test_direct_trust_jwk():
     mocked_issuer_jwt_vc_issuer_endpoint = unittest.mock.patch("pyeudiw.vci.jwks_provider.get_http_url", return_value=[jwt_vc_issuer_endpoint_response])
     mocked_issuer_jwt_vc_issuer_endpoint.start()
 
-    trust_source = DirectTrustSdJwtVc(**DEFAULT_DIRECT_TRUST_PARAMS)
+    trust_source = DirectTrustSdJwtVc(**DEFAULT_DIRECT_TRUST_SD_JWC_VC_PARAMS)
     obtained_jwks = trust_source.get_public_keys(issuer)
 
     mocked_issuer_jwt_vc_issuer_endpoint.stop()

--- a/pyeudiw/tests/trust/test_dynamic.py
+++ b/pyeudiw/tests/trust/test_dynamic.py
@@ -1,4 +1,4 @@
-from pyeudiw.trust.default import DEFAULT_DIRECT_TRUST_PARAMS
+from pyeudiw.trust.default import DEFAULT_DIRECT_TRUST_SD_JWC_VC_PARAMS
 from pyeudiw.trust.default.direct_trust_sd_jwt_vc import DirectTrustSdJwtVc
 from pyeudiw.trust.dynamic import CombinedTrustEvaluator, dynamic_trust_evaluators_loader
 from pyeudiw.trust.interface import TrustEvaluator
@@ -69,7 +69,7 @@ def test_trust_evaluators_loader():
 def test_combined_trust_evaluator():
     evaluators = {
         "mock": MockTrustEvaluator(),
-        "direct_trust_sd_jwt_vc": DirectTrustSdJwtVc(**DEFAULT_DIRECT_TRUST_PARAMS)
+        "direct_trust_sd_jwt_vc": DirectTrustSdJwtVc(**DEFAULT_DIRECT_TRUST_SD_JWC_VC_PARAMS)
     }
     combined = CombinedTrustEvaluator(evaluators)
     # TODO: re-enable when fixed

--- a/pyeudiw/trust/default/__init__.py
+++ b/pyeudiw/trust/default/__init__.py
@@ -1,20 +1,6 @@
-import os
-
-from pyeudiw.trust.default.direct_trust_sd_jwt_vc import DirectTrustSdJwtVc
+from pyeudiw.trust.default.direct_trust_sd_jwt_vc import DEFAULT_DIRECT_TRUST_SD_JWC_VC_PARAMS, DirectTrustSdJwtVc
 from pyeudiw.trust.interface import TrustEvaluator
 
 
-DEFAULT_DIRECT_TRUST_PARAMS = {
-    "httpc_params": {
-        "connection": {
-            "ssl": os.getenv("PYEUDIW_HTTPC_SSL", True)
-        },
-        "session": {
-            "timeout": os.getenv("PYEUDIW_HTTPC_TIMEOUT", 6)
-        }
-    }
-}
-
-
 def default_trust_evaluator() -> TrustEvaluator:
-    return DirectTrustSdJwtVc(**DEFAULT_DIRECT_TRUST_PARAMS)
+    return DirectTrustSdJwtVc(**DEFAULT_DIRECT_TRUST_SD_JWC_VC_PARAMS)

--- a/pyeudiw/trust/default/direct_trust_sd_jwt_vc.py
+++ b/pyeudiw/trust/default/direct_trust_sd_jwt_vc.py
@@ -1,4 +1,6 @@
+import os
 import time
+from typing import Optional
 
 from pyeudiw.tools.utils import get_http_url
 from pyeudiw.trust.interface import TrustEvaluator
@@ -8,6 +10,16 @@ from pyeudiw.vci.utils import cacheable_get_http_url
 
 DEFAULT_ISSUER_JWK_ENDPOINT = "/.well-known/jwt-vc-issuer"
 DEFAULT_METADATA_ENDPOINT = "/.well-known/openid-credential-issuer"
+DEFAULT_DIRECT_TRUST_SD_JWC_VC_PARAMS = {
+    "httpc_params": {
+        "connection": {
+            "ssl": os.getenv("PYEUDIW_HTTPC_SSL", True)
+        },
+        "session": {
+            "timeout": os.getenv("PYEUDIW_HTTPC_TIMEOUT", 6)
+        }
+    }
+}
 
 
 class DirectTrust(TrustEvaluator):
@@ -22,8 +34,10 @@ class DirectTrustSdJwtVc(DirectTrust):
     Such keys/metadata can always be fetched remotely and long as the issuer is
     available.
     """
-    def __init__(self, httpc_params: dict, cache_ttl: int = 0, jwk_endpoint: str = DEFAULT_ISSUER_JWK_ENDPOINT,
+    def __init__(self, httpc_params: Optional[dict] = None, cache_ttl: int = 0, jwk_endpoint: str = DEFAULT_ISSUER_JWK_ENDPOINT,
                  metadata_endpoint: str = DEFAULT_METADATA_ENDPOINT):
+        if httpc_params is None:
+            self.httpc_params = DEFAULT_DIRECT_TRUST_SD_JWC_VC_PARAMS["httpc_params"]
         self.httpc_params = httpc_params
         self.cache_ttl = cache_ttl
         self.jwk_endpoint = jwk_endpoint


### PR DESCRIPTION
With the proposed fix, direct trust sdjwt vc module can be used when httpc parameters are not defined. In that case, parameters are taken from environment variable, with default fallback value.

This fixes #279 