### PR TITLE
docs: Add  table for environment variables in README.SATOSA.md

### DIFF
--- a/README.SATOSA.md
+++ b/README.SATOSA.md
@@ -184,3 +184,16 @@ Configure an httpd fronted such NginX, an example is available within the `uwsgi
 remember to customize and add any additional parameter to your preferred httpd configuration.
 
 
+## Environment Variables Configuration
+SATOSA supports the following environment variables to customize its behavior:
+| **Variable Name**                | **Description**                                                                  | **Default Value**   | **Allowed Values**         | **Context**               |
+| -------------------------------- | -------------------------------------------------------------------------------- | ------------------- | -------------------------- | ------------------------- |
+| `PYEUDIW_MONGO_TEST_AUTH_INLINE` | MongoDB connection string used for SATOSA integration tests.                     | `""` (empty string) | Valid MongoDB URI          | Integration Testing       |
+| `PYEUDIW_LRU_CACHE_MAXSIZE`          | Configures the maximum number of elements to store in the Least Recently Used (LRU) cache.            | `2048`                    | Integer                          | Cache Management               |
+| `PYEUDIW_HTTPC_SSL`              | Enables or disables SSL verification for HTTP client requests.                   | `True`              | `True`, `False`            | HTTP Client Configuration |
+| `PYEUDIW_HTTPC_TIMEOUT`          | Sets the timeout for HTTP client requests.                                       | `6` seconds        | Integer                    | HTTP Client Configuration |
+| `SD_JWT_HEADER`                  | Specifies the type of SD-JWT header to use when generating or verifying SD-JWTs. | `dc+sd-jwt`           | Custom values as per usage | SD-JWT Configuration      |
+
+### Notes:
+1. These variables are optional and, if not explicitly set, default values will be used.
+2. To define these variables, you can use export commands in shell scripts, or any environment variable management tool.

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -25,12 +25,7 @@ HTTPC parameters are optional and described below.
 | httpc_params.connection | dictionary that represents a `aiohttp._RequestOptions` used in GET requests |
 | httpc_params.session    | dictionary that represents the keyword arguments of `aiohttp.ClientSession` |
 
-Some HTTPC parameters are commonly used, have a default value and as an alternative can be optionally defined by an environment variable.
-
-| Parameter                    | Description                                                     | Default Value | Environment Variable  |
-| ---------------------------- | --------------------------------------------------------------- | ------------- | --------------------- |
-| httpc_params.connection.ssl  | The flag to indicate whether to use SSL for the HTTP connection | true          | PYEUDIW_HTTPC_SSL     |
-| httpc_params.session.timeout | The timeout value for the HTTP session                          | 6             | PYEUDIW_HTTPC_TIMEOUT |
+Some HTTPC parameters are commonly used, have a default value and as an alternative can be optionally defined by an  [environment variable](https://github.com/italia/eudi-wallet-it-python/blob/dev/README.SATOSA.md).
 
 ### Federation
 

--- a/pyeudiw/tools/utils.py
+++ b/pyeudiw/tools/utils.py
@@ -249,7 +249,7 @@ def cacheable_get_http_url(cache_ttl: int, url: str, httpc_params: dict, http_as
     return resp
 
 
-@lru_cache(os.getenv("PYEUDIW_LRU_CACHE_TTL", 2048))
+@lru_cache(os.getenv("PYEUDIW_LRU_CACHE_MAXSIZE", 2048))
 def _lru_cached_get_http_url(timestamp: int, url: str, httpc_params_tuple: _HttpcParams_T, http_async: bool = True) -> requests.Response:
     """
     Wraps method 'get_http_url' around a ttl cache.


### PR DESCRIPTION
Add env table to readme.md

The environment variable `PYEUDIW_LRU_CACHE_TTL` has been renamed to `PYEUDIW_LRU_CACHE_MAXSIZE` to accurately reflect its function, which defines the maximum capacity (`maxsize`) of the cache used by the `lru_cache` decorator. This update removes ambiguity in the naming and aligns the documentation with the actual behavior of the variable in the code.
