### PR TITLE
feat: publish trust metadata endpoint

### DIFF
--- a/example/satosa/integration_test/cross_device_integration_test.py
+++ b/example/satosa/integration_test/cross_device_integration_test.py
@@ -15,7 +15,8 @@ from commons import (
     create_authorize_response,
     create_holder_test_data,
     create_issuer_test_data,
-    extract_saml_attributes
+    extract_saml_attributes,
+    verify_request_object_jwt
 )
 from settings import TIMEOUT_S
 
@@ -76,6 +77,8 @@ def run(playwright: Playwright):
         request_uri,
         verify=False,
         timeout=TIMEOUT_S)
+
+    verify_request_object_jwt(sign_request_obj.text, wallet_user_agent)
 
     request_object_claims = decode_jwt_payload(sign_request_obj.text)
     response_uri = request_object_claims["response_uri"]

--- a/example/satosa/integration_test/same_device_integration_test.py
+++ b/example/satosa/integration_test/same_device_integration_test.py
@@ -12,7 +12,8 @@ from commons import (
     create_authorize_response,
     create_holder_test_data,
     create_issuer_test_data,
-    extract_saml_attributes
+    extract_saml_attributes,
+    verify_request_object_jwt
 )
 from settings import TIMEOUT_S
 
@@ -55,6 +56,8 @@ sign_request_obj = http_user_agent.get(
     request_uri,
     verify=False,
     timeout=TIMEOUT_S)
+
+verify_request_object_jwt(sign_request_obj.text, http_user_agent)
 
 request_object_claims = decode_jwt_payload(sign_request_obj.text)
 response_uri = request_object_claims["response_uri"]

--- a/example/satosa/pyeudiw_backend.yaml
+++ b/example/satosa/pyeudiw_backend.yaml
@@ -99,11 +99,12 @@ config:
       q: 2jMFt2iFrdaYabdXuB4QMboVjPvbLA-IVb6_0hSG_-EueGBvgcBxdFGIZaG6kqHqlB7qMsSzdptU0vn6IgmCZnX-Hlt6c5X7JB_q91PZMLTO01pbZ2Bk58GloalCHnw_mjPh0YPviH5jGoWM5RHyl_HDDMI-UeLkzP7ImxGizrM
 
   trust:
-    direct_trust_jar:
+    direct_trust_sd_jwt_vc:
       module: pyeudiw.trust.default.direct_trust_sd_jwt_vc
       class: DirectTrustSdJwtVc
       config:
         jwk_endpoint: /.well-known/jwt-vc-issuer
+    direct_trust_jar:
       module: pyeudiw.trust.handler.direct_trust_jar
       class: DirectTrustJar
       config:

--- a/example/satosa/pyeudiw_backend.yaml
+++ b/example/satosa/pyeudiw_backend.yaml
@@ -80,12 +80,32 @@ config:
       session:
         timeout: 6
 
+  # private jwk
+  metadata_jwks: &metadata_jwks
+    - crv: P-256
+      d: KzQBowMMoPmSZe7G8QsdEWc1IvR2nsgE8qTOYmMcLtc
+      kid: dDwPWXz5sCtczj7CJbqgPGJ2qQ83gZ9Sfs-tJyULi6s
+      use: sig
+      kty: EC
+      x: TSO-KOqdnUj5SUuasdlRB2VVFSqtJOxuR5GftUTuBdk
+      y: ByWgQt1wGBSnF56jQqLdoO1xKUynMY-BHIDB3eXlR7
+    - kty: RSA
+      d: QUZsh1NqvpueootsdSjFQz-BUvxwd3Qnzm5qNb-WeOsvt3rWMEv0Q8CZrla2tndHTJhwioo1U4NuQey7znijhZ177bUwPPxSW1r68dEnL2U74nKwwoYeeMdEXnUfZSPxzs7nY6b7vtyCoA-AjiVYFOlgKNAItspv1HxeyGCLhLYhKvS_YoTdAeLuegETU5D6K1xGQIuw0nS13Icjz79Y8jC10TX4FdZwdX-NmuIEDP5-s95V9DMENtVqJAVE3L-wO-NdDilyjyOmAbntgsCzYVGH9U3W_djh4t3qVFCv3r0S-DA2FD3THvlrFi655L0QHR3gu_Fbj3b9Ybtajpue_Q
+      e: AQAB
+      use: enc
+      kid: 9Cquk0X-fNPSdePQIgQcQZtD6J0IjIRrFigW2PPK_-w
+      n: utqtxbs-jnK0cPsV7aRkkZKA9t4S-WSZa3nCZtYIKDpgLnR_qcpeF0diJZvKOqXmj2cXaKFUE-8uHKAHo7BL7T-Rj2x3vGESh7SG1pE0thDGlXj4yNsg0qNvCXtk703L2H3i1UXwx6nq1uFxD2EcOE4a6qDYBI16Zl71TUZktJwmOejoHl16CPWqDLGo9GUSk_MmHOV20m4wXWkB4qbvpWVY8H6b2a0rB1B1YPOs5ZLYarSYZgjDEg6DMtZ4NgiwZ-4N1aaLwyO-GLwt9Vf-NBKwoxeRyD3zWE2FXRFBbhKGksMrCGnFDsNl5JTlPjaM3kYyImE941ggcuc495m-Fw
+      p: 2zmGXIMCEHPphw778YjVTar1eycih6fFSJ4I4bl1iq167GqO0PjlOx6CZ1-OdBTVU7HfrYRiUK_BnGRdPDn-DQghwwkB79ZdHWL14wXnpB5y-boHz_LxvjsEqXtuQYcIkidOGaMG68XNT1nM4F9a8UKFr5hHYT5_UIQSwsxlRQ0
+      q: 2jMFt2iFrdaYabdXuB4QMboVjPvbLA-IVb6_0hSG_-EueGBvgcBxdFGIZaG6kqHqlB7qMsSzdptU0vn6IgmCZnX-Hlt6c5X7JB_q91PZMLTO01pbZ2Bk58GloalCHnw_mjPh0YPviH5jGoWM5RHyl_HDDMI-UeLkzP7ImxGizrM
+
   trust:
-    direct_trust_sd_jwt_vc:
-      module: pyeudiw.trust.default.direct_trust_sd_jwt_vc
-      class: DirectTrustSdJwtVc
+    direct_trust_jar:
+      module: pyeudiw.trust.handler.direct_trust_jar
+      class: DirectTrustJar  # TODO: see https://github.com/italia/eudi-wallet-it-python/issues/296#issuecomment-2491417276
       config:
         jwk_endpoint: /.well-known/jwt-vc-issuer
+        jar_issuer_endpoint: /.well-known/jar-issuer
+        jwks: *metadata_jwks
     federation:
       module: pyeudiw.trust.default.federation
       class: FederationTrustModel
@@ -120,25 +140,6 @@ config:
             - "todo"
         trust_anchors_cn: # we might mix CN and SAN together
             - http://127.0.0.1:8000
-
-  # private jwk
-  metadata_jwks: 
-    - crv: P-256
-      d: KzQBowMMoPmSZe7G8QsdEWc1IvR2nsgE8qTOYmMcLtc
-      kid: dDwPWXz5sCtczj7CJbqgPGJ2qQ83gZ9Sfs-tJyULi6s
-      use: sig
-      kty: EC
-      x: TSO-KOqdnUj5SUuasdlRB2VVFSqtJOxuR5GftUTuBdk
-      y: ByWgQt1wGBSnF56jQqLdoO1xKUynMY-BHIDB3eXlR7
-    - kty: RSA
-      d: QUZsh1NqvpueootsdSjFQz-BUvxwd3Qnzm5qNb-WeOsvt3rWMEv0Q8CZrla2tndHTJhwioo1U4NuQey7znijhZ177bUwPPxSW1r68dEnL2U74nKwwoYeeMdEXnUfZSPxzs7nY6b7vtyCoA-AjiVYFOlgKNAItspv1HxeyGCLhLYhKvS_YoTdAeLuegETU5D6K1xGQIuw0nS13Icjz79Y8jC10TX4FdZwdX-NmuIEDP5-s95V9DMENtVqJAVE3L-wO-NdDilyjyOmAbntgsCzYVGH9U3W_djh4t3qVFCv3r0S-DA2FD3THvlrFi655L0QHR3gu_Fbj3b9Ybtajpue_Q
-      e: AQAB
-      use: enc
-      kid: 9Cquk0X-fNPSdePQIgQcQZtD6J0IjIRrFigW2PPK_-w
-      n: utqtxbs-jnK0cPsV7aRkkZKA9t4S-WSZa3nCZtYIKDpgLnR_qcpeF0diJZvKOqXmj2cXaKFUE-8uHKAHo7BL7T-Rj2x3vGESh7SG1pE0thDGlXj4yNsg0qNvCXtk703L2H3i1UXwx6nq1uFxD2EcOE4a6qDYBI16Zl71TUZktJwmOejoHl16CPWqDLGo9GUSk_MmHOV20m4wXWkB4qbvpWVY8H6b2a0rB1B1YPOs5ZLYarSYZgjDEg6DMtZ4NgiwZ-4N1aaLwyO-GLwt9Vf-NBKwoxeRyD3zWE2FXRFBbhKGksMrCGnFDsNl5JTlPjaM3kYyImE941ggcuc495m-Fw
-      p: 2zmGXIMCEHPphw778YjVTar1eycih6fFSJ4I4bl1iq167GqO0PjlOx6CZ1-OdBTVU7HfrYRiUK_BnGRdPDn-DQghwwkB79ZdHWL14wXnpB5y-boHz_LxvjsEqXtuQYcIkidOGaMG68XNT1nM4F9a8UKFr5hHYT5_UIQSwsxlRQ0
-      q: 2jMFt2iFrdaYabdXuB4QMboVjPvbLA-IVb6_0hSG_-EueGBvgcBxdFGIZaG6kqHqlB7qMsSzdptU0vn6IgmCZnX-Hlt6c5X7JB_q91PZMLTO01pbZ2Bk58GloalCHnw_mjPh0YPviH5jGoWM5RHyl_HDDMI-UeLkzP7ImxGizrM
-
 
   # Mongodb database configuration
   storage:

--- a/example/satosa/pyeudiw_backend.yaml
+++ b/example/satosa/pyeudiw_backend.yaml
@@ -100,11 +100,14 @@ config:
 
   trust:
     direct_trust_jar:
+      module: pyeudiw.trust.default.direct_trust_sd_jwt_vc
+      class: DirectTrustSdJwtVc
+      config:
+        jwk_endpoint: /.well-known/jwt-vc-issuer
       module: pyeudiw.trust.handler.direct_trust_jar
       class: DirectTrustJar
       config:
-        jwk_endpoint: /.well-known/jwt-vc-issuer
-        jar_issuer_endpoint: /.well-known/jar-issuer
+        jwk_endpoint: /.well-known/jar-issuer
         jwks: *metadata_jwks
     federation:
       module: pyeudiw.trust.default.federation

--- a/example/satosa/pyeudiw_backend.yaml
+++ b/example/satosa/pyeudiw_backend.yaml
@@ -101,7 +101,7 @@ config:
   trust:
     direct_trust_jar:
       module: pyeudiw.trust.handler.direct_trust_jar
-      class: DirectTrustJar  # TODO: see https://github.com/italia/eudi-wallet-it-python/issues/296#issuecomment-2491417276
+      class: DirectTrustJar
       config:
         jwk_endpoint: /.well-known/jwt-vc-issuer
         jar_issuer_endpoint: /.well-known/jar-issuer

--- a/pyeudiw/satosa/default/openid4vp_backend.py
+++ b/pyeudiw/satosa/default/openid4vp_backend.py
@@ -108,7 +108,10 @@ class OpenID4VPBackend(OpenID4VPBackendInterface, BackendTrust):
         :rtype: Sequence[(str, Callable[[satosa.context.Context], satosa.response.Response]]
         :return: A list that can be used to map the request to SATOSA to this endpoint.
         """
-        url_map: list[tuple[str, Callable[[Context], Response]]] = self.trust_evaluator.build_metadata_endpoints(self.client_id)
+        url_map = self.trust_evaluator.build_metadata_endpoints(
+            self.name,
+            self.client_id
+        )
 
         for k, v in self.config['endpoints'].items():
             endpoint_value = v

--- a/pyeudiw/satosa/default/openid4vp_backend.py
+++ b/pyeudiw/satosa/default/openid4vp_backend.py
@@ -110,7 +110,7 @@ class OpenID4VPBackend(OpenID4VPBackendInterface, BackendTrust):
         """
         url_map: list[tuple[str, Callable[[Context], Response]]] = []
         base_path = f"{self.name}"
-        url_map = self.trust_evaluator.build_metadata_endpoints(base_path)
+        url_map = self.trust_evaluator.build_metadata_endpoints(self.client_id)
         
         for k, v in self.config['endpoints'].items():
             endpoint_value = v

--- a/pyeudiw/satosa/default/openid4vp_backend.py
+++ b/pyeudiw/satosa/default/openid4vp_backend.py
@@ -108,7 +108,10 @@ class OpenID4VPBackend(OpenID4VPBackendInterface, BackendTrust):
         :rtype: Sequence[(str, Callable[[satosa.context.Context], satosa.response.Response]]
         :return: A list that can be used to map the request to SATOSA to this endpoint.
         """
-        url_map = []
+        url_map: list[tuple[str, Callable[[Context], Response]]] = []
+        base_path = f"{self.name}"
+        url_map = self.trust_evaluator.build_metadata_endpoints(base_path)
+        
         for k, v in self.config['endpoints'].items():
             endpoint_value = v
 
@@ -122,7 +125,7 @@ class OpenID4VPBackend(OpenID4VPBackendInterface, BackendTrust):
 
             url_map.append(
                 (
-                    f"^{self.name}/{endpoint_value.lstrip('/')}$",
+                    f"^{base_path}/{endpoint_value.lstrip('/')}$",
                     getattr(self, f"{k}_endpoint")
                 )
             )

--- a/pyeudiw/satosa/default/openid4vp_backend.py
+++ b/pyeudiw/satosa/default/openid4vp_backend.py
@@ -108,10 +108,8 @@ class OpenID4VPBackend(OpenID4VPBackendInterface, BackendTrust):
         :rtype: Sequence[(str, Callable[[satosa.context.Context], satosa.response.Response]]
         :return: A list that can be used to map the request to SATOSA to this endpoint.
         """
-        url_map: list[tuple[str, Callable[[Context], Response]]] = []
-        base_path = f"{self.name}"
-        url_map = self.trust_evaluator.build_metadata_endpoints(self.client_id)
-        
+        url_map: list[tuple[str, Callable[[Context], Response]]] = self.trust_evaluator.build_metadata_endpoints(self.client_id)
+
         for k, v in self.config['endpoints'].items():
             endpoint_value = v
 
@@ -125,7 +123,7 @@ class OpenID4VPBackend(OpenID4VPBackendInterface, BackendTrust):
 
             url_map.append(
                 (
-                    f"^{base_path}/{endpoint_value.lstrip('/')}$",
+                    f"^{self.name}/{endpoint_value.lstrip('/')}$",
                     getattr(self, f"{k}_endpoint")
                 )
             )

--- a/pyeudiw/satosa/default/response_handler.py
+++ b/pyeudiw/satosa/default/response_handler.py
@@ -10,7 +10,6 @@ from satosa.context import Context
 from satosa.internal import AuthenticationInformation, InternalData
 from satosa.response import Redirect
 
-from pyeudiw.jwk import JWK
 from pyeudiw.openid4vp.authorization_response import AuthorizeResponseDirectPost, AuthorizeResponsePayload
 from pyeudiw.openid4vp.exceptions import InvalidVPKeyBinding, InvalidVPToken, KIDNotFound
 from pyeudiw.openid4vp.interface import VpTokenParser, VpTokenVerifier

--- a/pyeudiw/tests/satosa/test_backend.py
+++ b/pyeudiw/tests/satosa/test_backend.py
@@ -76,7 +76,7 @@ class TestOpenID4VPBackend:
             Mock(), INTERNAL_ATTRIBUTES, CONFIG, BASE_URL, "name")
         
         url_map = self.backend.register_endpoints()
-        assert len(url_map) == 6
+        assert len(url_map) == 7
 
     @pytest.fixture
     def internal_attributes(self):

--- a/pyeudiw/tests/satosa/test_dynamic_backed.py
+++ b/pyeudiw/tests/satosa/test_dynamic_backed.py
@@ -43,11 +43,11 @@ def test_dynamic_backend_creation():
     backend = OpenID4VPBackend(
         Mock(), INTERNAL_ATTRIBUTES, CONFIG, BASE_URL, "name")
 
-    endpoints = backend.register_endpoints()
-
-    assert endpoints[0][0] == "^name/.well-known/openid-federation$"
-    assert endpoints[2][0] == "^name/response_test$"
-    assert endpoints[3][0] == "^name/request_test$"
+    handlers = backend.register_endpoints()
+    published_endpoints = [handlers[i][0] for i in range(len(handlers))]
+    assert "^name/.well-known/openid-federation$" in published_endpoints
+    assert "^name/response_test$" in published_endpoints
+    assert "^name/request_test$" in published_endpoints
 
     context = Context()
     context.state = State()

--- a/pyeudiw/tests/trust/handler/__init__.py
+++ b/pyeudiw/tests/trust/handler/__init__.py
@@ -20,6 +20,14 @@ def _generate_response(issuer: str, issuer_jwk: dict) -> requests.Response:
     return jwt_vc_issuer_endpoint_response
 
 
+def _generate_empty_json_ok_response() -> requests.Response:
+    resp = requests.Response()
+    resp.status_code = 200
+    resp.headers.update({"Content-Type": "application/json"})
+    resp._content = json.dumps({}).encode('utf-8')
+    return resp
+
+
 issuer = "https://credential-issuer.example/vct/"
 issuer_jwk = {
     "kty": "EC",

--- a/pyeudiw/tests/trust/handler/test_direct_trust_jar.py
+++ b/pyeudiw/tests/trust/handler/test_direct_trust_jar.py
@@ -1,0 +1,138 @@
+from dataclasses import dataclass
+import json
+
+from pyeudiw.jwk import JWK
+import pytest
+import satosa.context
+import satosa.response
+
+from pyeudiw.trust.handler.direct_trust_jar import DirectTrustJar
+
+
+@pytest.fixture
+def signing_private_key() -> list[dict]:
+    return [{
+        "crv": "P-256",
+        "d": "r8UhwdbIvxKLvObVE-yixibCtu-0nzBZ3QGQ_-i1owc",
+        "kid": "MmjIDEhSnyIha4n462iIzrmdwMnJWlRZnsOJ3LWBEC4",
+        "kty": "EC",
+        "use": "sig",
+        "x": "xEmx9ruaf1qycPoYQ5lIfMSXAz2qLib6n0Ar_WDEiHM",
+        "y": "ZkSlQyYxuVTEKNRdrnONTisTepQ-3VcCza2O2yejawQ"
+    }]
+
+
+@pytest.fixture
+def all_private_keys(signing_private_key: list[dict]) -> list[dict]:
+    rsa_pkey = {
+        "d": "l2vENvwM3YVZ7C36mDKGJIjaadzhc_3JSuUrj5PUj1DMRfDf5jElrseIg8hyWhi5n6FqN8uV_2hfw-xUarwx_glFtbe0StqVqHLAYpGg7Id8fe5CKUPsjweNBq9zx9EMKNZl5q_tBW4ZnhyLhbmv-tO0NUz2ht2moOOPsqycNymblxs3bIZKTLxwEfx9rBhXkOUJ8MWciRjvaA1kOTY5pT__AnhmEdqCGaqgSxfmf4tyudatREt7mhnOQqIPtyVPFFCHZHsHv5Akp9U7bA2cbke8NarfBlLbZufzj2sSaVErAn-po1KIB3fuA9HBs4YeDGcRv3hipUJrACMqYm5zhODdSr-P6X-3-FR5EWnSDUDwYeWZ7q1jzGzgKAXEbnn-CXY_JlXaYGfRUqIXui883rr9IjqI-c1TVcSPaSVpnxut9rwfkxuQo7MEbiExODGfXNvbR9S8DWJXWjKmFZklResqK6wWFe7GXkDLDeWRtbtRxEYirIkxPgNt3EXcm3sp",
+        "e": "AQAB",
+        "kid": "KwJFzr11BxhSmAW8D2ZGBDQRdiQXZo1YWGaxHGW5Md8",
+        "kty": "RSA",
+        "n": "wDBeA9a1xgOEb_zwm05cZnblBJANfWBA7oaZRYLp1sl0030pK6jHyEJ4wrXlMMQcxvwOx80uRFJG3o9BLTQ5lPnBu-VMAxF9LTkLZRD_gAJsrHz_myCgfcCMouX9AwDtUC01p5IIZ8YgfrbYPn694RxhCmH09oGs_OwOr7f3aW2qwf7uha7LRy8UPDYULnST7eqqWgrxjSIeHnmeO9BmEfcvqZJD2EfFHwFVXkjwMk1nWnQZYRV7Yncoz3qV0rhIQ86FQ2i4BoMW54OnRrgRHGqVUBHZP2y_Z3xo6foYOXJMgkHcEasiLbiATvHHN1cVsaM0PvQjO15qZu2IvVK224MgY6YbWU88pssG0ydTSOo0bY5gDhY6ml133MKXzfES0dzLNoOALrkyFxiHrPgQiFMKBuPXZ6qk1RomEWZYR54Brd7gDyK66MkdmpHvgBJf_V1YO42U1yxUTg63shdRp4O8FNZoTmhjMT9A_ZCD5mqGo00IewLHiQzVyWDqNrPv", "p": "0P7Vjj2Rc8tGdxqXvg77FsUaJIpoffgHSv59zrctOF7odKRYOSKW9FvlOi01NZE8dkcdYxlnriy3jyQVdGTxbRKJKKHrJbIJpqMDj6wUrk0k-67PbBuAJhzhmU_2wlyd04U7lt8gcn55kyV5XxQta6WTHz11MgO1GKePfCIlTRyS1T26_5wq5a_Q_VcdmiKuBHm0HtkBCkSYTWxWqfQjehs8eR5xOBAasgZHNit1KCMiONeUNyFtVFWgSSjDzhfL", "q": "62ngt1zghnj8pguWq1Xx6hRtE-eFS5K0rn6hSCgkLnUQeZWpO7cB4EEHFbN5FlWFIj9bjrRIoTQtHwprtM7dMqVaBH2HcKwSDiZy9ImmW2peKrP7Ko1t-Eg9Mhm8rycuzrwu3iQdd41JH-My5Fti-IuXyhZ3IVF_JvVNQKf4_RZQD4mbslEc6KFjLT-A3V6wfMhVFw7rnR6GcyQ0YUJTjzhRP3siG1A3GYGF1eN0pqT_3Lk2tvkd174BwcifiGft", "qi": "TFYkChfG3DRtgOiPRzl_yj_CDrYNsGWM-s0GmRHy_Zl1NvHK9u8Pc4hPoS9xx_qZiBnapX_Jmkaz39Q0GsjsJqjQQRxPMIofh1SZzH6O_tJ1-YQhJO4OfsQwi_FIAoDXHetkxnnhG1Axpvfqx5UyKM18uBz1vfWVrpfqaz9EBT04roVR_RFGzzV9jzDXFaZ17SWvovGtpHKqkVrCU0z6D8FV0lhuyBTmee6jXcxfzkwizGR6VexfaVwAHj7OdDGs",
+        "use": "enc"
+    }
+    return signing_private_key + [rsa_pkey]
+
+
+@pytest.fixture
+def direct_trust_jar(all_private_keys):
+    return DirectTrustJar(jwks=all_private_keys)
+
+
+def test_direct_trust_jar_build_metadata_path(direct_trust_jar):
+    @dataclass
+    class TestCase:
+        entity_id: str
+        expected_path: str
+        explanation: str
+
+    test_cases: list[TestCase] = [
+        TestCase(
+            entity_id="https://rp.example",
+            expected_path=".well-known/jar-issuer",
+            explanation="host without path component"
+        ),
+        TestCase(
+            entity_id="https://rp.example/openid4vp",
+            expected_path="openid4vp/.well-known/jar-issuer",
+            explanation="host with path component"
+        ),
+        TestCase(
+            entity_id="http://localhost:8080/openid4vp",
+            expected_path="openid4vp/.well-known/jar-issuer",
+            explanation="localhost with port"
+        )
+    ]
+
+    for i, case in enumerate(test_cases):
+        path_component = direct_trust_jar._build_metadata_path(case.entity_id)
+        assert path_component == case.expected_path, f"failed case {
+            i+1}: test scenario: {case.explanation}"
+
+
+def test_direct_trust_jat_custom_path(all_private_keys):
+    @dataclass
+    class TestCase:
+        endpoint_component: str
+        entity_id: str
+        expected_path: str
+        explanation: str
+
+    test_cases: list[TestCase] = [
+        TestCase(
+            endpoint_component="custom",
+            entity_id="https://rp.example/openid4vp",
+            expected_path="openid4vp/custom",
+            explanation="custom path"
+        ),
+        TestCase(
+            endpoint_component="/custom-with-slashes/",
+            entity_id="https://rp.example/openid4vp",
+            expected_path="openid4vp/custom-with-slashes",
+            explanation="custom path with prepending and appending forward slash"
+        )
+    ]
+    for i, case in enumerate(test_cases):
+        dtj = DirectTrustJar(jwks=all_private_keys,
+                             jar_issuer_endpoint=case.endpoint_component)
+        path_component = dtj._build_metadata_path(case.entity_id)
+        assert path_component == case.expected_path, f"failed case {
+            i+1}: test scenario: {case.explanation}"
+
+
+def test_direct_trust_jar_metadata(direct_trust_jar):
+    entity_id = "https://rp.example/openid4vp"
+    metadata = direct_trust_jar._build_jar_issuer_metadata(entity_id)
+    assert metadata["iss"] == entity_id
+    assert len(metadata["jwks"]["keys"]) == 1
+    pub_key = metadata["jwks"]["keys"][0]
+    assert "d" not in pub_key
+    assert pub_key.get("use", "") != "enc"
+
+
+def test_direct_trust_metadata_handler(direct_trust_jar, signing_private_key):
+    entity_id = "https://rp.example/openid4vp"
+    registered_methods = direct_trust_jar.build_metadata_endpoints(entity_id)
+    assert len(registered_methods) == 1
+
+    endpoint_regexp = registered_methods[0][0]
+    assert endpoint_regexp == "^openid4vp/.well-known/jar-issuer$"
+
+    http_handler = registered_methods[0][1]
+    empty_context = satosa.context.Context()
+    response = http_handler(empty_context, "test")
+    assert "200" in response.status
+    assert response._content_type == "application/json"
+    try:
+        response.headers.index(("Content-Type", "application/json"))
+    except Exception as e:
+        assert True, f"unable to find application/json in repsonse content type: {e}"
+
+    response_data = json.loads(response.message)
+    assert response_data["iss"] == entity_id
+    assert len(response_data["jwks"]["keys"]) == 1
+
+    pub_key = response_data["jwks"]["keys"][0]
+    expected_pub_key = JWK(signing_private_key[0]).as_public_dict()
+    assert pub_key == expected_pub_key

--- a/pyeudiw/tests/trust/handler/test_direct_trust_jar.py
+++ b/pyeudiw/tests/trust/handler/test_direct_trust_jar.py
@@ -67,8 +67,7 @@ def test_direct_trust_jar_build_metadata_path(direct_trust_jar):
 
     for i, case in enumerate(test_cases):
         path_component = direct_trust_jar._build_metadata_path(case.backend_name)
-        assert path_component == case.expected_path, f"failed case {
-            i+1}: test scenario: {case.explanation}"
+        assert path_component == case.expected_path, f"failed case {i+1}: test scenario: {case.explanation}"
 
 
 def test_direct_trust_jat_custom_path(all_private_keys):

--- a/pyeudiw/tests/trust/handler/test_direct_trust_jar.py
+++ b/pyeudiw/tests/trust/handler/test_direct_trust_jar.py
@@ -93,8 +93,7 @@ def test_direct_trust_jat_custom_path(all_private_keys):
         )
     ]
     for i, case in enumerate(test_cases):
-        dtj = DirectTrustJar(jwks=all_private_keys,
-                             jar_issuer_endpoint=case.endpoint_component)
+        dtj = DirectTrustJar(jwks=all_private_keys, jwk_endpoint=case.endpoint_component)
         path_component = dtj._build_metadata_path(case.backend_name)
         assert path_component == case.expected_path, f"failed case {i+1}: test scenario: {case.explanation}"
 
@@ -102,7 +101,7 @@ def test_direct_trust_jat_custom_path(all_private_keys):
 def test_direct_trust_jar_metadata(direct_trust_jar):
     backend = "openid4vp"
     entity_id = f"https://rp.example/{backend}"
-    metadata = direct_trust_jar._build_jar_issuer_metadata(entity_id)
+    metadata = direct_trust_jar._build_metadata_with_issuer_jwk(entity_id)
     assert metadata["iss"] == entity_id
     assert len(metadata["jwks"]["keys"]) == 1
     pub_key = metadata["jwks"]["keys"][0]

--- a/pyeudiw/tests/trust/handler/test_direct_trust_jar.py
+++ b/pyeudiw/tests/trust/handler/test_direct_trust_jar.py
@@ -96,8 +96,7 @@ def test_direct_trust_jat_custom_path(all_private_keys):
         dtj = DirectTrustJar(jwks=all_private_keys,
                              jar_issuer_endpoint=case.endpoint_component)
         path_component = dtj._build_metadata_path(case.backend_name)
-        assert path_component == case.expected_path, f"failed case {
-            i+1}: test scenario: {case.explanation}"
+        assert path_component == case.expected_path, f"failed case {i+1}: test scenario: {case.explanation}"
 
 
 def test_direct_trust_jar_metadata(direct_trust_jar):

--- a/pyeudiw/trust/dynamic.py
+++ b/pyeudiw/trust/dynamic.py
@@ -164,13 +164,13 @@ class CombinedTrustEvaluator(BaseLogger):
 
         if not trust_source.trust_params:
             raise Exception(f"no trust evaluator can provide trust parameters for {issuer}: searched among: {self.handlers_names}")
-        
+
         return {type: param.trust_params for type, param in trust_source.trust_params.items()}
 
-    def build_metadata_endpoints(self, base_path: str) -> list[tuple[str, Callable[[satosa.context.Context, Any], satosa.response.Response]]]:
+    def build_metadata_endpoints(self, entity_uri: str) -> list[tuple[str, Callable[[satosa.context.Context, Any], satosa.response.Response]]]:
         endpoints = []
         for handler in self.handlers:
-            endpoints += handler.build_metadata_endpoints(base_path)
+            endpoints += handler.build_metadata_endpoints(entity_uri)
         # Partially check for collissions in managed paths: this might happen if multiple configured
         # trust frameworks want to handle the same endpoints (check is not 100% exhaustive as paths are actually regexps)
         all_paths = [path for path, *_ in endpoints]

--- a/pyeudiw/trust/dynamic.py
+++ b/pyeudiw/trust/dynamic.py
@@ -174,7 +174,7 @@ class CombinedTrustEvaluator(BaseLogger):
         # Partially check for collissions in managed paths: this might happen if multiple configured
         # trust frameworks want to handle the same endpoints (check is not 100% exhaustive as paths are actually regexps)
         all_paths = [path for path, *_ in endpoints]
-        if len(all_paths) > set(all_paths):
+        if len(all_paths) > len(set(all_paths)):
             self._log_warning("build_metadata_endpoints", f"found collision in metadata endpoint: {all_paths}")
         return endpoints
 

--- a/pyeudiw/trust/dynamic.py
+++ b/pyeudiw/trust/dynamic.py
@@ -167,10 +167,10 @@ class CombinedTrustEvaluator(BaseLogger):
 
         return {type: param.trust_params for type, param in trust_source.trust_params.items()}
 
-    def build_metadata_endpoints(self, entity_uri: str) -> list[tuple[str, Callable[[satosa.context.Context, Any], satosa.response.Response]]]:
+    def build_metadata_endpoints(self, backend_name: str, entity_uri: str) -> list[tuple[str, Callable[[satosa.context.Context, Any], satosa.response.Response]]]:
         endpoints = []
         for handler in self.handlers:
-            endpoints += handler.build_metadata_endpoints(entity_uri)
+            endpoints += handler.build_metadata_endpoints(backend_name, entity_uri)
         # Partially check for collissions in managed paths: this might happen if multiple configured
         # trust frameworks want to handle the same endpoints (check is not 100% exhaustive as paths are actually regexps)
         all_paths = [path for path, *_ in endpoints]

--- a/pyeudiw/trust/handler/_direct_trust_jwk.py
+++ b/pyeudiw/trust/handler/_direct_trust_jwk.py
@@ -1,0 +1,180 @@
+from typing import Any, Callable, Literal
+from urllib.parse import urlparse
+import satosa.context
+import satosa.response
+
+from pyeudiw.jwk import JWK
+from pyeudiw.satosa.utils.response import JsonResponse
+from pyeudiw.tools.base_logger import BaseLogger
+from pyeudiw.tools.utils import cacheable_get_http_url, get_http_url
+
+from pyeudiw.trust.handler.exception import InvalidJwkMetadataException
+from pyeudiw.trust.handler.interface import TrustHandlerInterface
+from pyeudiw.trust.model.trust_source import TrustSourceData
+
+
+class _DirectTrustJwkHandler(TrustHandlerInterface, BaseLogger):
+    """
+    This is class used to group common logic among classes that fetch of expose
+    cryptogrpahic material in the form of a JWKS (Json Web Kwy Set) at a known
+    endpoint, which is usually a /.well-known endpoint.
+
+    It assumes that exposed in the protocol-defined endpoints is trusted even
+    when it is not backed up by a proper trust attestation leading to a known and
+    recognized root of trust.
+
+    _DirectTrustJwkHandler supports an simple in memory LRU (least recently used)
+    cache with expiration.
+
+    Attributes:
+        httpc_params: connection parameters used to make http requests, if required.
+        jwk_endpoint: endpoint component used to publish own public keys or to \
+            fetch other entities keys; usually in the form of a /.well-known.
+        cache_ttl: maximum cache duration, in seconds.
+        jwks: list of private keys (possible none) that are owned by the trust \
+            evaluation mechanism and that might be exposes when presenting to \
+            the others as token issuer.
+    """
+
+    def __init__(
+        self,
+        httpc_params: dict,
+        jwk_endpoint: str,
+        cache_ttl: int,
+        jwks: list[dict] | None
+    ):
+        self.httpc_params = httpc_params
+        self.jwk_endpoint = jwk_endpoint
+        self.cache_ttl = cache_ttl
+        self.http_async_calls = False
+        # input validation
+        self.jwks = jwks if jwks else []
+        try:
+            [JWK(key=key) for key in self.jwks]
+        except Exception as e:
+            raise ValueError("invalid argument: dictionary is not a jwk", e)
+
+    def _build_issuing_public_signing_jwks(self) -> list[dict]:
+        signing_keys = [
+            key for key in self.jwks if key.get("use", "") != "enc"]
+        return [
+            JWK(key).as_public_dict() for key in signing_keys
+        ]
+
+    def _build_metadata_with_issuer_jwk(self, entity_id: str) -> dict:
+        # This funciton assumed that the issuer is equal to the entity_uri; this
+        #  is currently an implementation detail and might not hold in the future;
+        # This could also be resolved by extrating the request uri from the satosa
+        #  context; but for not we will opt for the simple option.
+        md_dictionary = {
+            "iss": entity_id,
+            "jwks": {
+                "keys": self._build_issuing_public_signing_jwks()
+            }
+        }
+        return md_dictionary
+
+    def _build_metadata_path(self, backend_name: str) -> str:
+        """
+        If the entity URI is https://<hotst>/<path>, then the built metadata
+        path will be <path>/.well-known/jar-issuer (or the equivalent
+        configured terminating portion <path>/<jwk_endpoint>).
+
+        IMPORTANT: If the path that should be exposed MUST start with
+        `/.well-known/`, then that issue must be solved at the wsgi-nginx
+        level as it breaks an assuptions of the internal satosa router and
+        there is no way to solve that problem at the satosa backend level.
+        """
+        endpoint = backend_name.strip('/') + '/' + self.jwk_endpoint.strip("/")
+        return endpoint.strip('/')
+
+    def _extract_jwks_from_jwk_metadata(self, metadata: dict) -> dict:
+        """
+        parse the jwk metadata document and return the jwks
+        NOTE: jwks might be in the document by value or by reference
+        """
+        jwks: dict[Literal["keys"], list[dict]] | None = metadata.get("jwks", None)
+        jwks_uri: str | None = metadata.get("jwks_uri", None)
+        if (not jwks) and (not jwks_uri):
+            raise InvalidJwkMetadataException("invalid issuing key metadata: missing both claims [jwks] and [jwks_uri]")
+        if jwks:
+            # get jwks by value
+            return jwks
+        return self._get_jwks_by_reference(jwks_uri)
+
+    def _get_jwk_metadata(self, issuer_id: str) -> dict:
+        if not self.jwk_endpoint:
+            return {}
+        endpoint = build_jwk_issuer_endpoint(issuer_id, self.jwk_endpoint)
+        if self.cache_ttl:
+            resp = cacheable_get_http_url(
+                self.cache_ttl, endpoint, self.httpc_params, http_async=self.http_async_calls)
+        else:
+            resp = get_http_url([endpoint], self.httpc_params, http_async=self.http_async_calls)[0]
+        if (not resp) or (resp.status_code != 200):
+            raise InvalidJwkMetadataException(
+                f"failed to fetch valid jwk metadata: obtained {resp}")
+        return resp.json()
+
+    def _get_jwks_by_reference(self, jwks_reference_uri: str) -> dict:
+        """
+        call the jwks endpoint if jwks is defined by reference
+        """
+        if self.cache_ttl:
+            resp = cacheable_get_http_url(
+                self.cache_ttl, jwks_reference_uri, self.httpc_params, http_async=self.http_async_calls)
+        else:
+            resp = get_http_url(
+                [jwks_reference_uri], self.httpc_params, http_async=self.http_async_calls)[0]
+        return resp.json()
+
+    def build_metadata_endpoints(self, backend_name: str, entity_uri: str) -> list[tuple[str, Callable[[satosa.context.Context, Any], satosa.response.Response]]]:
+        if not self.jwk_endpoint:
+            return []
+
+        metadata_path = '^' + self._build_metadata_path(backend_name) + '$'
+        response_json = self._build_metadata_with_issuer_jwk(entity_uri)
+
+        def metadata_response_fn(ctx: satosa.context.Context, *args) -> satosa.response.Response:
+            return JsonResponse(message=response_json)
+        return [(metadata_path, metadata_response_fn)]
+
+    def extract_and_update_trust_materials(self, issuer: str, trust_source: TrustSourceData) -> TrustSourceData:
+        """
+        Fetches the public key of the issuer by querying a given endpoint.
+        Previous responses might or might not be cached based on the cache_ttl
+        parameter.
+
+        :returns: a list of jwk(s)
+        """
+        if not issuer:
+            raise ValueError("invalid issuer: cannot be empty value")
+
+        try:
+            self.get_metadata(issuer, trust_source)
+            md = self._get_jwk_metadata(issuer)
+            if not issuer == (obt_issuer := md.get("issuer", None)):
+                raise InvalidJwkMetadataException(f"invalid jwk metadata: obtained issuer :{obt_issuer}, expected issuer: {issuer}")
+            jwks = self._extract_jwks_from_jwk_metadata(md)
+            jwk_l: list[dict] = jwks.get("keys", [])
+            if not jwk_l:
+                raise InvalidJwkMetadataException("unable to find jwks in issuer jwk metadata")
+
+            trust_source.add_keys(jwk_l)
+        except Exception as e:
+            self._log_warning(
+                "Extracting JWK", f"Failed to extract jwks from issuer {issuer}: {e}")
+
+        return trust_source
+
+    def get_metadata(self, issuer: str, trust_source: TrustSourceData) -> TrustSourceData:
+        # this class does not handle generic metadata information: it fetches and exposes cryptographic material only
+        return trust_source
+
+
+def build_jwk_issuer_endpoint(issuer_id: str, endpoint_component: str) -> str:
+    if not endpoint_component:
+        return issuer_id
+    baseurl = urlparse(issuer_id)
+    full_endpoint_path = '/' + endpoint_component.strip('/') + baseurl.path
+    return baseurl._replace(path=full_endpoint_path).geturl()

--- a/pyeudiw/trust/handler/direct_trust_jar.py
+++ b/pyeudiw/trust/handler/direct_trust_jar.py
@@ -27,7 +27,7 @@ class DirectTrustJar(DirectTrustSdJwtVc):
             operation; each list element is a dicctionary that represent a jwk.
         jar_issuer_endpoint: partial path component that identify which path \
             component specify this endpoint.
-        *args, **kwargs: other attributes as decribed in \
+        **kwargs: parent class attributes initialized at constructor as decribed in \
             pyeudiw.trust.handler.direct_trust_sd_jwt_vc.DirectTrustSdJwtVc
     """
 
@@ -36,12 +36,11 @@ class DirectTrustJar(DirectTrustSdJwtVc):
         try:
             [JWK(key=key) for key in jwks]
         except Exception as e:
-            raise ValueError("invalid argumentt: dictionary is not a jwk", e)
+            raise ValueError("invalid argument: dictionary is not a jwk", e)
         self.jwks = jwks
         self.jar_issuer_endpoint = jar_issuer_endpoint
 
     def _build_public_signing_jwks(self) -> list[dict]:
-        # for security reason, the only serializable object is the public portion of a jwk.
         signing_keys = [
             key for key in self.jwks if key.get("use", "") != "enc"]
         return [
@@ -52,7 +51,7 @@ class DirectTrustJar(DirectTrustSdJwtVc):
         # This funciton assumed that the issuer is equal to the entity_uri; this
         #  is currently an implementation detail and might not hold in the future;
         # This could also be resolved by extrating the request uri from the satosa
-        #  context; but for not we will opt the simple option.
+        #  context; but for not we will opt for the simple option.
         md_dictionary = {
             "iss": entity_id,
             "jwks": {
@@ -61,7 +60,7 @@ class DirectTrustJar(DirectTrustSdJwtVc):
         }
         return md_dictionary
 
-    def _build_metadata_path(self, entity_uri: str) -> str:
+    def _build_metadata_path(self, backend_name: str) -> str:
         """
         If the entity URI is https://<hotst>/<path>, then the built metadata
         path will be <path>/.well-known/jar-issuer (or the equivalent
@@ -69,16 +68,14 @@ class DirectTrustJar(DirectTrustSdJwtVc):
 
         IMPORTANT: If the path that should be exposed MUST start with
         `/.well-known/`, then that issue must be solved at the wsgi-nginx
-        level as it breaks the assuptions of the internal satosa router and
+        level as it breaks an assuptions of the internal satosa router and
         there is no way to solve that problem at the satosa backend level.
         """
-        base_uri = urlparse(entity_uri)
-        endpoint_component = '/' + self.jar_issuer_endpoint.strip("/")
-        base_md_endpoint = base_uri._replace(path=base_uri.path + endpoint_component)
-        return base_md_endpoint.path.strip('/')
+        endpoint = backend_name.strip('/') + '/' + self.jar_issuer_endpoint.strip("/")
+        return endpoint.strip('/')
 
-    def build_metadata_endpoints(self, entity_uri: str) -> list[tuple[str, Callable[[satosa.context.Context, Any], satosa.response.Response]]]:
-        metadata_path = '^' + self._build_metadata_path(entity_uri) + '$'
+    def build_metadata_endpoints(self, backend_name: str, entity_uri: str) -> list[tuple[str, Callable[[satosa.context.Context, Any], satosa.response.Response]]]:
+        metadata_path = '^' + self._build_metadata_path(backend_name) + '$'
         response_json = self._build_jar_issuer_metadata(entity_uri)
 
         def metadata_response_fn(ctx: satosa.context.Context, *args) -> satosa.response.Response:

--- a/pyeudiw/trust/handler/direct_trust_jar.py
+++ b/pyeudiw/trust/handler/direct_trust_jar.py
@@ -1,0 +1,89 @@
+import json
+from typing import Any, Callable
+
+from urllib.parse import urlparse
+
+from pyeudiw.jwk import JWK
+import satosa.context
+import satosa.response
+
+from pyeudiw.trust.handler.direct_trust_sd_jwt_vc import DirectTrustSdJwtVc
+
+
+DEFAULT_JARISSUER_METADATA_ENDPOINT = "/.well-known/jar-issuer"
+"""Default endpoint adopted by potential interopebility document as of version 1.1.
+The endpopint should be positioned between the host component and the path component (if any) of the iss claim value in the JAR.
+"""
+
+
+class DirectTrustJar(DirectTrustSdJwtVc):
+    """
+    DirectTrustJar extends DirectTrustSdJwtVC model to include exposure of \
+    metadata information at a given known endpoint.
+
+    Attributes:
+        jwks: list off private keys thgat can be used to permorm cryptographic \
+            operation; each list element is a dicctionary that represent a jwk.
+        jar_issuer_endpoint: partial path component that identify which path \
+            component specify this endpoint.
+        *args, **kwargs: other attributes as decribed in \
+            pyeudiw.trust.handler.direct_trust_sd_jwt_vc.DirectTrustSdJwtVc
+    """
+
+    def __init__(self, jwks: list[dict], jar_issuer_endpoint: str = DEFAULT_JARISSUER_METADATA_ENDPOINT, **kwargs):
+        super().__init__(**kwargs)
+        try:
+            [JWK(key=key) for key in jwks]
+        except Exception as e:
+            raise ValueError("invalid argumentt: dictionary is not a jwk", e)
+        self.jwks = jwks
+        self.jar_issuer_endpoint = jar_issuer_endpoint
+
+    def _build_public_signing_jwks(self) -> list[dict]:
+        # for security reason, the only serializable object is the public portion of a jwk.
+        signing_keys = [
+            key for key in self.jwks if key.get("use", "") != "enc"]
+        return [
+            JWK(key).as_public_dict() for key in signing_keys
+        ]
+
+    def _build_jar_issuer_metadata(self, entity_id: str) -> str:
+        # This funciton assumed that the issuer is equal to the entity_uri; this
+        #  is currently an implementation detail and might not hold in the future;
+        # This could also be resolved by extrating the request uri from the satosa
+        #  context; but for not we will opt the simple option.
+        md_dictionary = {
+            "iss": entity_id,
+            "jwks": {
+                "keys": self._build_public_signing_jwks()
+            }
+        }
+        return json.dumps(md_dictionary)
+
+    def _build_metadata_path(self, entity_uri: str) -> str:
+        """
+        If the entity URI is https://<hotst>/<path>, then the built metadata
+        path will be <path>/.well-known/jar-issuer (or the equivalent
+        configured terminating portion).
+
+        IMPORTANT: If the path that should be exposed MUST start with
+        `/.well-known/`, then that issue must be solved at the wsgi-nginx
+        level as it breaks the assuptions of the internal satosa router.
+        """
+        base_uri = urlparse(entity_uri)
+        endpoint_component = '/' + self.jar_issuer_endpoint.strip("/")
+        base_md_endpoint = base_uri._replace(path=base_uri.path + endpoint_component)
+        md_endpoint_path_regxp = '^' + base_md_endpoint.path.strip('/') + '$'
+        return md_endpoint_path_regxp
+
+    def build_metadata_endpoints(self, entity_uri: str) -> list[tuple[str, Callable[[satosa.context.Context, Any], satosa.response.Response]]]:
+        metadata_path = self._build_metadata_path(entity_uri)
+        serialized_content = self._build_jar_issuer_metadata(entity_uri)
+
+        def metadata_response_fn(ctx: satosa.context.Context) -> satosa.response.Response:
+            return satosa.response.Response(
+                message=serialized_content,
+                content="application/json",
+                status="200"
+            )
+        return [(metadata_path, metadata_response_fn)]

--- a/pyeudiw/trust/handler/direct_trust_jar.py
+++ b/pyeudiw/trust/handler/direct_trust_jar.py
@@ -1,14 +1,6 @@
-import json
-from typing import Any, Callable
+import os
 
-from urllib.parse import urlparse
-
-from pyeudiw.jwk import JWK
-import satosa.context
-import satosa.response
-from pyeudiw.satosa.utils.response import JsonResponse
-
-from pyeudiw.trust.handler.direct_trust_sd_jwt_vc import DirectTrustSdJwtVc
+from pyeudiw.trust.handler._direct_trust_jwk import _DirectTrustJwkHandler
 
 
 DEFAULT_JARISSUER_METADATA_ENDPOINT = "/.well-known/jar-issuer"
@@ -16,68 +8,31 @@ DEFAULT_JARISSUER_METADATA_ENDPOINT = "/.well-known/jar-issuer"
 The endpopint should be positioned between the host component and the path component (if any) of the iss claim value in the JAR.
 """
 
+DEFAULT_DIRECT_TRUST_JAR_HTTPC_PARAMS = {
+    "connection": {
+        "ssl": os.getenv("PYEUDIW_HTTPC_SSL", True)
+    },
+    "session": {
+        "timeout": os.getenv("PYEUDIW_HTTPC_TIMEOUT", 6)
+    }
+}
 
-class DirectTrustJar(DirectTrustSdJwtVc):
+
+class DirectTrustJar(_DirectTrustJwkHandler):
+    """DirectTrustJar is specialization of _DirectTrustJwkHandler
+    used in the context of JAR (RFC9101).
     """
-    DirectTrustJar extends DirectTrustSdJwtVC model to include exposure of \
-    metadata information at a given known endpoint.
 
-    Attributes:
-        jwks: list off private keys thgat can be used to permorm cryptographic \
-            operation; each list element is a dicctionary that represent a jwk.
-        jar_issuer_endpoint: partial path component that identify which path \
-            component specify this endpoint.
-        **kwargs: parent class attributes initialized at constructor as decribed in \
-            pyeudiw.trust.handler.direct_trust_sd_jwt_vc.DirectTrustSdJwtVc
-    """
-
-    def __init__(self, jwks: list[dict], jar_issuer_endpoint: str = DEFAULT_JARISSUER_METADATA_ENDPOINT, **kwargs):
-        super().__init__(**kwargs)
-        try:
-            [JWK(key=key) for key in jwks]
-        except Exception as e:
-            raise ValueError("invalid argument: dictionary is not a jwk", e)
-        self.jwks = jwks
-        self.jar_issuer_endpoint = jar_issuer_endpoint
-
-    def _build_public_signing_jwks(self) -> list[dict]:
-        signing_keys = [
-            key for key in self.jwks if key.get("use", "") != "enc"]
-        return [
-            JWK(key).as_public_dict() for key in signing_keys
-        ]
-
-    def _build_jar_issuer_metadata(self, entity_id: str) -> dict:
-        # This funciton assumed that the issuer is equal to the entity_uri; this
-        #  is currently an implementation detail and might not hold in the future;
-        # This could also be resolved by extrating the request uri from the satosa
-        #  context; but for not we will opt for the simple option.
-        md_dictionary = {
-            "iss": entity_id,
-            "jwks": {
-                "keys": self._build_public_signing_jwks()
-            }
-        }
-        return md_dictionary
-
-    def _build_metadata_path(self, backend_name: str) -> str:
-        """
-        If the entity URI is https://<hotst>/<path>, then the built metadata
-        path will be <path>/.well-known/jar-issuer (or the equivalent
-        configured terminating portion).
-
-        IMPORTANT: If the path that should be exposed MUST start with
-        `/.well-known/`, then that issue must be solved at the wsgi-nginx
-        level as it breaks an assuptions of the internal satosa router and
-        there is no way to solve that problem at the satosa backend level.
-        """
-        endpoint = backend_name.strip('/') + '/' + self.jar_issuer_endpoint.strip("/")
-        return endpoint.strip('/')
-
-    def build_metadata_endpoints(self, backend_name: str, entity_uri: str) -> list[tuple[str, Callable[[satosa.context.Context, Any], satosa.response.Response]]]:
-        metadata_path = '^' + self._build_metadata_path(backend_name) + '$'
-        response_json = self._build_jar_issuer_metadata(entity_uri)
-
-        def metadata_response_fn(ctx: satosa.context.Context, *args) -> satosa.response.Response:
-            return JsonResponse(message=response_json)
-        return [(metadata_path, metadata_response_fn)]
+    def __init__(
+        self,
+        httpc_params: dict = DEFAULT_DIRECT_TRUST_JAR_HTTPC_PARAMS,
+        jwk_endpoint: str = DEFAULT_JARISSUER_METADATA_ENDPOINT,
+        cache_ttl: int = 0,
+        jwks: list[dict] | None = None
+    ):
+        super().__init__(
+            httpc_params=httpc_params,
+            jwk_endpoint=jwk_endpoint,
+            cache_ttl=cache_ttl,
+            jwks=jwks
+        )

--- a/pyeudiw/trust/handler/direct_trust_sd_jwt_vc.py
+++ b/pyeudiw/trust/handler/direct_trust_sd_jwt_vc.py
@@ -1,12 +1,8 @@
 import os
-from typing import Literal
-from urllib.parse import ParseResult, urlparse
 
-from pyeudiw.trust.handler.interface import TrustHandlerInterface
+from pyeudiw.trust.handler._direct_trust_jwk import _DirectTrustJwkHandler
 from pyeudiw.trust.model.trust_source import TrustSourceData
-from pyeudiw.tools.base_logger import BaseLogger
 from pyeudiw.tools.utils import cacheable_get_http_url, get_http_url
-from pyeudiw.trust.handler.exception import InvalidJwkMetadataException
 
 
 DEFAULT_SDJWTVC_METADATA_ENDPOINT = "/.well-known/jwt-vc-issuer"
@@ -29,16 +25,9 @@ DEFAULT_DIRECT_TRUST_SD_JWC_VC_PARAMS = {
 }
 
 
-class DirectTrustSdJwtVc(TrustHandlerInterface, BaseLogger):
-    """DirectTrustSdJwtVc is a trust handler that assumes that the key material
-    and metadata exposed in protocol-defined endpoints is trusted even when it
-    is not backed up by a proper trust attestation leading to a known and
-    recognized root of trust.
-    In practical terms, in direct trust we assume the the content exposed in
-    well-known endpoints of the issuing entities are always to be trusted.
-
-    DirectTrustSdJwtVc supports an simple in memory LRU (least recently used)
-    cache with expiration.
+class DirectTrustSdJwtVc(_DirectTrustJwkHandler):
+    """DirectTrustSdJwtVc is specialization of _DirectTrustJwkHandler
+    used in the context of sd-jwt for verifiable credentials.
     """
 
     def __init__(
@@ -47,87 +36,15 @@ class DirectTrustSdJwtVc(TrustHandlerInterface, BaseLogger):
         jwk_endpoint: str = DEFAULT_SDJWTVC_METADATA_ENDPOINT,
         metadata_endpoint: str = DEFAULT_OPENID4VCI_METADATA_ENDPOINT,
         cache_ttl: int = 0,
-    ) -> None:
-        self.httpc_params = httpc_params
-        self.jwk_endpoint = jwk_endpoint
+        jwks: list[dict] | None = None
+    ):
+        super().__init__(
+            httpc_params=httpc_params,
+            jwk_endpoint=jwk_endpoint,
+            cache_ttl=cache_ttl,
+            jwks=jwks
+        )
         self.metadata_endpoint = metadata_endpoint
-        self.cache_ttl = cache_ttl
-        self.http_async_calls = False
-
-    def _get_jwk_metadata(self, issuer: str) -> dict:
-        """
-        call the jwk metadata endpoint and return the whole document
-        """
-        jwk_endpoint = DirectTrustSdJwtVc.build_issuer_jwk_endpoint(issuer, self.jwk_endpoint)
-        if self.cache_ttl:
-            resp = cacheable_get_http_url(self.cache_ttl, jwk_endpoint, self.httpc_params, http_async=self.http_async_calls)
-        else:
-            resp = get_http_url([jwk_endpoint], self.httpc_params, http_async=self.http_async_calls)[0]
-        if (not resp) or (resp.status_code != 200):
-            raise InvalidJwkMetadataException(f"failed to fetch valid jwk metadata: obtained {resp}")
-        return resp.json()
-
-    def _get_jwks_by_reference(self, jwks_reference_uri: str) -> dict:
-        """
-        call the jwks endpoint if jwks is defined by reference
-        """
-        if self.cache_ttl:
-            resp = cacheable_get_http_url(self.cache_ttl, jwks_reference_uri, self.httpc_params, http_async=self.http_async_calls)
-        else:
-            resp = get_http_url([jwks_reference_uri], self.httpc_params, http_async=self.http_async_calls)[0]
-        return resp.json()
-
-    def _extract_jwks_from_jwk_metadata(self, metadata: dict) -> dict:
-        """
-        parse the jwk metadata document and return the jwks
-        NOTE: jwks might be in the document by value or by reference
-        """
-        jwks: dict[Literal["keys"], list[dict]] | None = metadata.get("jwks", None)
-        jwks_uri: str | None = metadata.get("jwks_uri", None)
-        if (not jwks) and (not jwks_uri):
-            raise InvalidJwkMetadataException("invalid issuing key metadata: missing both claims [jwks] and [jwks_uri]")
-        if jwks:
-            # get jwks by value
-            return jwks
-        return self._get_jwks_by_reference(jwks_uri)
-
-    def build_issuer_jwk_endpoint(issuer_id: str, well_known_path_component: str) -> str:
-        baseurl = urlparse(issuer_id)
-        well_known_path = well_known_path_component + baseurl.path
-        well_known_url: str = ParseResult(baseurl.scheme, baseurl.netloc, well_known_path, baseurl.params, baseurl.query, baseurl.fragment).geturl()
-        return well_known_url
-
-    def build_issuer_metadata_endpoint(issuer: str, metadata_path_component: str) -> str:
-        issuer_normalized = issuer if issuer[-1] != '/' else issuer[:-1]
-        return issuer_normalized + metadata_path_component
-
-    def extract_and_update_trust_materials(self, issuer: str, trust_source: TrustSourceData) -> TrustSourceData:
-        """
-        Fetches the public key of the issuer by querying a given endpoint.
-        Previous responses might or might not be cached based on the cache_ttl
-        parameter.
-
-        :returns: a list of jwk(s)
-        """
-        if not issuer:
-            raise ValueError("invalid issuer: cannot be empty value")
-        
-        try:
-            self.get_metadata(issuer, trust_source)
-
-            md = self._get_jwk_metadata(issuer)
-            if not issuer == (obt_issuer := md.get("issuer", None)):
-                raise InvalidJwkMetadataException(f"invalid jwk metadata: obtained issuer :{obt_issuer}, expected issuer: {issuer}")
-            jwks = self._extract_jwks_from_jwk_metadata(md)
-            jwk_l: list[dict] = jwks.get("keys", [])
-            if not jwk_l:
-                raise InvalidJwkMetadataException("unable to find jwks in issuer jwk metadata")
-            
-            trust_source.add_keys(jwk_l)
-        except Exception as e:
-            self._log_warning("Extracting JWK", f"Failed to extract jwks from issuer {issuer}: {e}")
-    
-        return trust_source
 
     def get_metadata(self, issuer: str, trust_source: TrustSourceData) -> TrustSourceData:
         """
@@ -137,11 +54,14 @@ class DirectTrustSdJwtVc(TrustHandlerInterface, BaseLogger):
 
         :returns: a dictionary of metadata information
         """
-        url = DirectTrustSdJwtVc.build_issuer_metadata_endpoint(issuer, self.metadata_endpoint)
-
+        url = build_metadata_issuer_endpoint(issuer, self.metadata_endpoint)
         if self.cache_ttl == 0:
             trust_source.metadata = get_http_url(url, self.httpc_params, self.http_async_calls)[0].json()
         else:
             trust_source.metadata = cacheable_get_http_url(self.cache_ttl, url, self.httpc_params, self.http_async_calls).json()
 
         return trust_source
+
+
+def build_metadata_issuer_endpoint(issuer_id: str, endpoint_component: str) -> str:
+    return issuer_id.rstrip('/') + '/' + endpoint_component.lstrip('/')

--- a/pyeudiw/trust/handler/interface.py
+++ b/pyeudiw/trust/handler/interface.py
@@ -28,18 +28,21 @@ class TrustHandlerInterface:
         :type issuer: str
         :param trust_source: The trust source to update
         :type trust_source: TrustSourceData
-        
+
         :returns: The updated trust source
         :rtype: TrustSourceData
         """
 
         raise NotImplementedError
 
-    def build_metadata_endpoints(self, entity_uri: str) -> list[tuple[str, Callable[[satosa.context.Context, Any], satosa.response.Response]]]:
+    def build_metadata_endpoints(self, backend_name: str, entity_uri: str) -> list[tuple[str, Callable[[satosa.context.Context, Any], satosa.response.Response]]]:
         """
         Expose one or more metadata endpoint required to publish metadata
         information about *myself* and that are associated to a trust
         mechanism, such as public keys, configurations, policies, etc.
+
+        The endpoint are attached to a backend whose name is equal to
+        the first function argument.
 
         The result of this method is a list of element where each one is of type
         ```
@@ -47,11 +50,14 @@ class TrustHandlerInterface:
         ```
         compliant to satosa.backend.BackendModule method register_endpoints, that is:
         1. the first argument is a regxp used for rotuing to that endpoint; while \
-            not required, this regexpt is likely to use the base_path argument
+            not required, due to satosa inernal routing restrictions, the regexp \
+            first path must match the backend.
         2. the second argument is an http handler that can provide a response given \
             the information in the context.
 
         The entity_uri is the full path component of the exposed satosa module.
+        In some context, this also matched the entity id of the module and can be
+        used as issuer value when signing tokens.
         We assume that the module is exposed to the outside web according to
         the follwing pattern
             <scheme>://<host>/<base_path>
@@ -65,6 +71,9 @@ class TrustHandlerInterface:
             http://satosa.exammple/openid4vp/.well-known/protocol-config
         while other protocols might require to register
             http://satosa.exammple/.well-known/protocol-config/openid4vp
+
+        However, due to satosa restrictions, the exposed endpoint MUST start with
+        the satosa module name.
 
         The TrustHandler might not have any associated metadata endpoint, in which case
         an empty list is returned instead.

--- a/pyeudiw/trust/handler/interface.py
+++ b/pyeudiw/trust/handler/interface.py
@@ -1,4 +1,9 @@
+from typing import Any, Callable
+import satosa.context
+import satosa.response
+
 from pyeudiw.trust.model.trust_source import TrustSourceData
+
 
 class TrustHandlerInterface:
     def extract_and_update_trust_materials(self, issuer: str, trust_source: TrustSourceData) -> TrustSourceData:
@@ -29,6 +34,42 @@ class TrustHandlerInterface:
         """
 
         raise NotImplementedError
+
+    def build_metadata_endpoints(self, base_path: str) -> list[tuple[str, Callable[[satosa.context.Context, Any], satosa.response.Response]]]:
+        """
+        Expose one or more metadata endpoint required to publish metadata
+        information about *myself* and that are associated to a trust
+        mechanism, such as public keys, configurations, policies, etc.
+
+        The result of this method is a list of element where each one is of type
+        ```
+            tuple[str, Callable[[satosa.context.Context, Any], satosa.response.Response]]
+        ```
+        compliant to satosa.backend.BackendModule method register_endpoints, that is:
+        1. the first argument is a regxp used for rotuing to that endpoint; while \
+            not required, this regexpt is likely to use the base_path argument
+        2. the second argument is an http handler that can provide a response given \
+            the information in the context.
+
+        The base_path is the base path component of the exposed satosa module.
+        We assume that the module is exposed to the outside web according to
+        the follwing pattern
+            <scheme>://<host>/<base_path>
+
+        The base path information might be required for appropriate routing. For
+        example, if the satosa entity is known to the outside element of a trust
+        network as
+            http://satosa.example/openid4vp,
+        then some trust frameworks might require to publish a well known information
+        at endpoint
+            http://satosa.exammple/openid4vp/.well-known/protocol-config
+        while other protocols might require to register
+            http://satosa.exammple/.well-known/protocol-config/openid4vp
+
+        The TrustHandler might not have any associated metadata endpoint, in which case
+        an empty list is returned instead.
+        """
+        return []
 
     @property
     def name(self) -> str:

--- a/pyeudiw/trust/handler/interface.py
+++ b/pyeudiw/trust/handler/interface.py
@@ -35,7 +35,7 @@ class TrustHandlerInterface:
 
         raise NotImplementedError
 
-    def build_metadata_endpoints(self, base_path: str) -> list[tuple[str, Callable[[satosa.context.Context, Any], satosa.response.Response]]]:
+    def build_metadata_endpoints(self, entity_uri: str) -> list[tuple[str, Callable[[satosa.context.Context, Any], satosa.response.Response]]]:
         """
         Expose one or more metadata endpoint required to publish metadata
         information about *myself* and that are associated to a trust
@@ -51,7 +51,7 @@ class TrustHandlerInterface:
         2. the second argument is an http handler that can provide a response given \
             the information in the context.
 
-        The base_path is the base path component of the exposed satosa module.
+        The entity_uri is the full path component of the exposed satosa module.
         We assume that the module is exposed to the outside web according to
         the follwing pattern
             <scheme>://<host>/<base_path>

--- a/pyeudiw/trust/interface.py
+++ b/pyeudiw/trust/interface.py
@@ -1,3 +1,8 @@
+from typing import Any, Callable
+import satosa.context
+import satosa.response
+
+
 class TrustEvaluator:
     """
     TrustEvaluator is an interface that defined the expected behaviour of a
@@ -29,6 +34,42 @@ class TrustEvaluator:
         trust model.
         """
         raise NotImplementedError
+
+    def build_metadata_endpoints(self, base_path: str) -> list[tuple[str, Callable[[satosa.context.Context, Any], satosa.response.Response]]]:
+        """
+        Expose one or more metadata endpoint required to publish metadata
+        information about *myself* and that are associated to a trust
+        mechanism, such as public keys, configurations, policies, etc.
+
+        The result of this method is a list of element where each one is of type
+        ```
+            tuple[str, Callable[[satosa.context.Context, Any], satosa.response.Response]]
+        ```
+        compliant to satosa.backend.BackendModule method register_endpoints, that is:
+        1. the first argument is a regxp used for rotuing to that endpoint; while \
+            not required, this regexpt is likely to use the base_path argument
+        2. the second argument is an http handler that can provide a response given \
+            the information in the context.
+
+        The base_path is the base path component of the exposed satosa module.
+        We assume that the module is exposed to the outside web according to
+        the follwing pattern
+            <scheme>://<host>/<base_path>
+
+        The base path information might be required for appropriate routing. For
+        example, if the satosa entity is known to the outside element of a trust
+        network as
+            http://satosa.example/openid4vp,
+        then some trust frameworks might require to publish a well known information
+        at endpoint
+            http://satosa.exammple/openid4vp/.well-known/protocol-config
+        while other protocols might require to register
+            http://satosa.exammple/.well-known/protocol-config/openid4vp
+
+        The TrustHandler might not have any associated metadata endpoint, in which case
+        an empty list is returned instead.
+        """
+        return []
 
     def is_revoked(self, issuer: str) -> bool:
         """


### PR DESCRIPTION
This PR includes the following:
1. extends the TrustHandler interface to allow the possibility to publish trust-framework defined endpoints
2. introduce a new trust evaluation mechanism, called DirectTrustJar, that extends DirectTrustSdJwtVc, to let RP publish its own signing keys

Notably, it does NOT update the former federation publication mechanism to use this new endpoint. This is because this task is not-trivial and probably requires a dedicated pull request.
With the exception above, this closes #312 and closes #296. When merged, a new issue should be opened to update federation.

Due to restrictions introduced by which endpoint can be exposed by a satosa backend module, integration tests require this modification to work https://github.com/italia/iam-proxy-italia/pull/177 . These two pull request are intended to be accepted side by side.