### PR TITLE
feat: support for direct_post (unencrypted) responses

### DIFF
--- a/example/satosa/integration_test/same_device_integration_test.py
+++ b/example/satosa/integration_test/same_device_integration_test.py
@@ -74,33 +74,10 @@ wallet_response_data = create_authorize_response(
 
 authz_response = http_user_agent.post(
     response_uri,
-    data={
-        "vp_token": verifiable_presentations,
-        "state": request_object_claims["state"],
-        "presentation_submission": {
-            "definition_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
-            "id": "04a98be3-7fb0-4cf5-af9a-31579c8b0e7d",
-            "descriptor_map": [
-                {
-                    "id": "pid-sd-jwt:unique_id+given_name+family_name",
-                    "path": "$.vp_token.verified_claims.claims._sd[0]",
-                    "format": "vc+sd-jwt"
-                }
-            ],
-            "aud": response_uri
-        }
-    },
-    headers={
-        "Content-Type": "application/x-www-form-urlencoded"
-    }
+    verify=False,
+    data={"response": wallet_response_data},
+    timeout=TIMEOUT_S
 )
-
-# authz_response = http_user_agent.post(
-#     response_uri,
-#     verify=False,
-#     data={"response": wallet_response_data},
-#     timeout=TIMEOUT_S
-# )
 
 assert authz_response.status_code == 200
 assert authz_response.json().get("redirect_uri", None) is not None

--- a/example/satosa/integration_test/same_device_integration_test.py
+++ b/example/satosa/integration_test/same_device_integration_test.py
@@ -74,10 +74,33 @@ wallet_response_data = create_authorize_response(
 
 authz_response = http_user_agent.post(
     response_uri,
-    verify=False,
-    data={"response": wallet_response_data},
-    timeout=TIMEOUT_S
+    data={
+        "vp_token": verifiable_presentations,
+        "state": request_object_claims["state"],
+        "presentation_submission": {
+            "definition_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+            "id": "04a98be3-7fb0-4cf5-af9a-31579c8b0e7d",
+            "descriptor_map": [
+                {
+                    "id": "pid-sd-jwt:unique_id+given_name+family_name",
+                    "path": "$.vp_token.verified_claims.claims._sd[0]",
+                    "format": "vc+sd-jwt"
+                }
+            ],
+            "aud": response_uri
+        }
+    },
+    headers={
+        "Content-Type": "application/x-www-form-urlencoded"
+    }
 )
+
+# authz_response = http_user_agent.post(
+#     response_uri,
+#     verify=False,
+#     data={"response": wallet_response_data},
+#     timeout=TIMEOUT_S
+# )
 
 assert authz_response.status_code == 200
 assert authz_response.json().get("redirect_uri", None) is not None

--- a/pyeudiw/openid4vp/authorization_response.py
+++ b/pyeudiw/openid4vp/authorization_response.py
@@ -21,7 +21,7 @@ def detect_response_mode(context: satosa.context.Context) -> ResponseMode:
     Try to make inference on which response mode type this is based on the
     content of an http request body
     """
-    if "response_uri" in context.request:
+    if "response" in context.request:
         return ResponseMode.direct_post_jwt
     if "vp_token" in context.request:
         return ResponseMode.direct_post

--- a/pyeudiw/openid4vp/authorization_response.py
+++ b/pyeudiw/openid4vp/authorization_response.py
@@ -6,7 +6,7 @@ from pyeudiw.jwk.exceptions import KidNotFoundError
 from pyeudiw.jwt.exceptions import JWEDecryptionError
 from pyeudiw.jwt.jwe_helper import JWEHelper
 from pyeudiw.jwt.jws_helper import JWSHelper
-from pyeudiw.jwt.utils import decode_jwt_header, is_jwe_format, is_jwt_format
+from pyeudiw.jwt.utils import decode_jwt_header
 
 from cryptojwt.jwk.ec import ECKey
 from cryptojwt.jwk.rsa import RSAKey
@@ -14,33 +14,7 @@ import cryptojwt.jwe.exception
 
 from pyeudiw.openid4vp.exceptions import AuthRespParsingException, AuthRespValidationException
 from pyeudiw.openid4vp.interface import AuthorizationResponseParser
-from pyeudiw.openid4vp.schemas.response import ResponseMode
-
-
-@dataclass
-class AuthorizeResponseDirectPostJwt:
-    response: str  # jwt
-
-    def __post_init__(self):
-        jwt = self.response
-        if not is_jwe_format(jwt) and not is_jwt_format(jwt):
-            raise ValueError(f"input response={jwt} is neither jwt not jwe format")
-
-
-@dataclass
-class AuthorizeResponsePayload:
-    """
-    AuthorizeResponsePayload is a simple schema class for
-        https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-response-parameters
-    only for the case when presentation submission is used over DCQL.
-
-    This class is a weaker validation than pyeudiw.openid4vp.schema.ResponseSchema
-    as it is not meant to validate the _content_ of the response; just that the
-    representation lands with the proper expected claims
-    """
-    state: str
-    vp_token: str | list[str]
-    presentation_submission: dict
+from pyeudiw.openid4vp.schemas.response import AuthorizeResponseDirectPostJwt, AuthorizeResponsePayload, ResponseMode
 
 
 def detect_response_mode(context: satosa.context.Context) -> ResponseMode:

--- a/pyeudiw/openid4vp/authorization_response.py
+++ b/pyeudiw/openid4vp/authorization_response.py
@@ -1,26 +1,74 @@
 from dataclasses import dataclass
 import json
+import satosa.context
 
 from pyeudiw.jwk.exceptions import KidNotFoundError
+from pyeudiw.jwt.exceptions import JWEDecryptionError
 from pyeudiw.jwt.jwe_helper import JWEHelper
 from pyeudiw.jwt.jws_helper import JWSHelper
-from pyeudiw.jwt.utils import decode_jwt_header, is_jwe_format, is_jwt_format
-
+from pyeudiw.jwt.utils import decode_jwt_header
 
 from cryptojwt.jwk.ec import ECKey
 from cryptojwt.jwk.rsa import RSAKey
+import cryptojwt.jwe.exception
 
-_RESPONSE_KEY = "response"
+from pyeudiw.openid4vp.exceptions import AuthRespParsingException, AuthRespValidationException
+from pyeudiw.openid4vp.interface import AuthorizationResponseParser
+from pyeudiw.openid4vp.schemas.response import AuthorizeResponseDirectPostJwt, AuthorizeResponsePayload
 
 
-@dataclass
-class AuthorizeResponsePayload:
-    state: str
-    vp_token: str | list[str]
-    presentation_submission: dict
+def _check_http_post_headers(context: satosa.context.Context):
+    if (http_method := context.request_method.upper()) != "POST":
+        raise AuthRespParsingException(f"HTTP method [{http_method}] not supported")
 
-    def serialize_json(self) -> str:
-        return json.dumps(self.__dict__)
+    if (content_type := context.http_headers['HTTP_CONTENT_TYPE']) != "application/x-www-form-urlencoded":
+        raise AuthRespParsingException(f"HTTP content type [{content_type}] not supported")
+
+
+class DirectPostParser(AuthorizationResponseParser):
+    """TODO: docsting
+    """
+
+    def __init__(self):
+        pass
+
+    def parse_and_validate(self, context: satosa.context.Context) -> AuthorizeResponsePayload:
+        _check_http_post_headers(context)
+
+        resp_data: dict = context.request
+        try:
+            return AuthorizeResponsePayload(**resp_data)
+        except Exception as e:
+            raise AuthRespParsingException("invalid data in direct_post request body", e)
+
+
+class DirectPostJwtParser(AuthorizationResponseParser):
+    """TODO: docstring
+    """
+
+    def __init__(self, jwe_decryptor: JWEHelper):
+        self.jwe_decryptor = jwe_decryptor
+        pass
+
+    def parse_and_validate(self, context: satosa.context.Context) -> AuthorizeResponsePayload:
+        _check_http_post_headers(context)
+        resp_data_raw: dict = context.request
+        try:
+            resp_data = AuthorizeResponseDirectPostJwt(**resp_data_raw)
+        except Exception as e:
+            raise AuthRespParsingException("invalid data in direct_post.jwt request body", e)
+        try:
+            payload = self.jwe_decryptor.decrypt(resp_data.response)
+        except JWEDecryptionError as e:
+            raise AuthRespParsingException("invalid data in direct_post.jwt request body: not a jwe", e)
+        except cryptojwt.jwe.exception.DecryptionFailed:
+            raise AuthRespValidationException("invalid data in direct_post.jwt: unable to decrypt token")
+        except Exception as e:
+            raise AuthRespParsingException("invalid data in direct_post.jwt request body", e)
+        try:
+            return AuthorizeResponsePayload(**payload)
+        except Exception as e:
+            raise AuthRespParsingException("invalid data in the direct_post.jwt: token payload does not have the expected claims", e)
 
 
 def _get_jwk_kid_from_store(jwt: str, key_store: dict[str, dict]) -> dict:
@@ -44,26 +92,3 @@ def _verify_and_decode_jwt(jwt: str, verifying_jwk: dict[dict, ECKey | RSAKey | 
     raw_payload: str = verifier.verify(jwt)["msg"]
     payload: dict = json.loads(raw_payload)
     return payload
-
-
-@dataclass
-class AuthorizeResponseDirectPost:
-    response: str  # jwt
-
-    def __post_init__(self):
-        jwt = self.response
-        if not is_jwe_format(jwt) and not is_jwt_format(jwt):
-            raise ValueError(f"input {_RESPONSE_KEY}={jwt} is neither jwt not jwe format")
-
-    def decode_payload(self, key_store_by_kid: dict[str, dict]) -> AuthorizeResponsePayload:
-        jwt = self.response
-        jwk_dict = _get_jwk_kid_from_store(jwt, key_store_by_kid)
-
-        payload = {}
-        if is_jwe_format(jwt):
-            payload = _decrypt_jwe(jwt, jwk_dict)
-        elif is_jwt_format(jwt):
-            payload = _verify_and_decode_jwt(jwt, jwk_dict)
-        else:
-            raise ValueError(f"unexpected state: input jwt={jwt} is neither a jwt nor a jwe")
-        return AuthorizeResponsePayload(**payload)

--- a/pyeudiw/openid4vp/exceptions.py
+++ b/pyeudiw/openid4vp/exceptions.py
@@ -1,3 +1,16 @@
+class AuthRespParsingException(Exception):
+    """Raised when the http request corresponding to an authorization response is malformed.
+    """
+    pass
+
+
+class AuthRespValidationException(Exception):
+    """Raised when the http request corresponding to an authorization response is well formed,
+    but not valid (for example, it might be wrapped in an expired token).
+    """
+    pass
+
+
 class KIDNotFound(Exception):
     """
     Raised when kid is not present in the public key dict

--- a/pyeudiw/openid4vp/interface.py
+++ b/pyeudiw/openid4vp/interface.py
@@ -1,7 +1,35 @@
 from cryptojwt.jwk.ec import ECKey
 from cryptojwt.jwk.rsa import RSAKey
+import satosa.context
 
 from pyeudiw.jwt.parse import KeyIdentifier_T
+from pyeudiw.openid4vp.schemas.response import AuthorizeResponsePayload
+
+
+class AuthorizationResponseParser:
+    """
+    DirectPostParser is an interface intended to parse direct POST http responses
+    """
+
+    def parse_and_validate(self, context: satosa.context.Context) -> AuthorizeResponsePayload:
+        """
+        Parse (and optionally validate) a satosa http request, wrapped in its own context.
+        The validation step might include verification tasks; for example if the data is
+        reepresented as a jwt, the validation should perform a check on the jwt validity.
+
+        :param context: an http request wrapped in its own satosa context
+        :type context: satosa.context.Context
+
+        :raises pyeudiw.openid4vp.exceptions.AuthRespParsingException: raised \
+            when the http response is malformed.
+        :raises pyeudiw.openid4vp.exceptions.AuthRespValidationException: raised \
+            when the http response is syntactically correct, but not valid (for \
+            example, it might be an expired token).
+
+        :return: the plain openid4vp authorization response; DCQL is not supported yet
+        :rtype: AuthorizeResponsePayload
+        """
+        raise NotImplementedError
 
 
 class VpTokenParser:

--- a/pyeudiw/openid4vp/interface.py
+++ b/pyeudiw/openid4vp/interface.py
@@ -8,14 +8,30 @@ from pyeudiw.openid4vp.schemas.response import AuthorizeResponsePayload
 
 class AuthorizationResponseParser:
     """
-    DirectPostParser is an interface intended to parse direct POST http responses
+    AuthorizationResponseParser is an interface intended to parse direct POST
+    http responses.
+
+    An authorization parser is meant to just parse and eventually validate the
+    "lower" applicaiton layer of the transmission, that is, it is used to
+    extract an authorization response from the HTTP layer.
+    It SHOULD NOT be used to validate the actual content of the response, that
+    is, it SHOULD NOT try to validate vp_tokens, presentation_submissions, etc.
+    This is a delicate task that that is best suited for a different, dedicated
+    object, method or interface.
     """
 
     def parse_and_validate(self, context: satosa.context.Context) -> AuthorizeResponsePayload:
         """
-        Parse (and optionally validate) a satosa http request, wrapped in its own context.
+        Parse (and optionally validate) a satosa http request, wrapped in its own
+        context, in order to extract an auhtorization response.
         The validation step might include verification tasks; for example if the data is
         reepresented as a jwt, the validation should perform a check on the jwt validity.
+
+        The concrete implementation SHOULD NOT be used to validate the actual content
+        of the response, that is, it SHOULD NOT try to validate vp_tokens,
+        presentation_submissions, etc.
+        This is a delicate task that that is best suited for a different, dedicated
+        object, method or interface.
 
         :param context: an http request wrapped in its own satosa context
         :type context: satosa.context.Context

--- a/pyeudiw/openid4vp/schemas/response.py
+++ b/pyeudiw/openid4vp/schemas/response.py
@@ -1,9 +1,10 @@
+from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
 from pydantic import BaseModel, field_validator
 
-from pyeudiw.jwt.utils import is_jwt_format
+from pyeudiw.jwt.utils import is_jwe_format, is_jwt_format
 
 
 class DescriptorSchema(BaseModel):
@@ -36,3 +37,28 @@ class ResponseSchema(BaseModel):
             return vp_token
         else:
             raise ValueError("vp_token is not in a JWT format.")
+
+@dataclass
+class AuthorizeResponseDirectPostJwt:
+    response: str  # jwt
+
+    def __post_init__(self):
+        jwt = self.response
+        if not is_jwe_format(jwt) and not is_jwt_format(jwt):
+            raise ValueError(f"input response={jwt} is neither jwt not jwe format")
+
+
+@dataclass
+class AuthorizeResponsePayload:
+    """
+    AuthorizeResponsePayload is a simple schema class for
+        https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-response-parameters
+    only for the case when presentation submission is used over DCQL.
+
+    This class is a weaker validation than pyeudiw.openid4vp.schema.ResponseSchema
+    as it is not meant to validate the _content_ of the response; just that the
+    representation lands with the proper expected claims
+    """
+    state: str
+    vp_token: str | list[str]
+    presentation_submission: dict

--- a/pyeudiw/openid4vp/schemas/response.py
+++ b/pyeudiw/openid4vp/schemas/response.py
@@ -1,38 +1,38 @@
-from enum import Enum
-from typing import Optional
+from dataclasses import dataclass
 
-from pydantic import BaseModel, field_validator
-
-from pyeudiw.jwt.utils import is_jwt_format
+from pyeudiw.jwt.utils import is_jwe_format, is_jwt_format
 
 
-class DescriptorSchema(BaseModel):
-    id: str
-    path: str
-    format: str
+@dataclass
+class AuthorizeResponseDirectPostJwt:
+    response: str  # jwt
+
+    def __post_init__(self):
+        jwt = self.response
+        if not is_jwe_format(jwt) and not is_jwt_format(jwt):
+            raise ValueError(f"input response={jwt} is neither jwt not jwe format")
+
+    # def decode_payload(self, key_store_by_kid: dict[str, dict]) -> AuthorizeResponsePayload:
+    #     jwt = self.response
+    #     jwk_dict = _get_jwk_kid_from_store(jwt, key_store_by_kid)
+
+    #     payload = {}
+    #     if is_jwe_format(jwt):
+    #         payload = _decrypt_jwe(jwt, jwk_dict)
+    #     elif is_jwt_format(jwt):
+    #         payload = _verify_and_decode_jwt(jwt, jwk_dict)
+    #     else:
+    #         raise ValueError(f"unexpected state: input jwt={jwt} is neither a jwt nor a jwe")
+    #     return AuthorizeResponsePayload(**payload)
 
 
-class PresentationSubmissionSchema(BaseModel):
-    definition_id: str
-    id: str
-    descriptor_map: list[DescriptorSchema]
-
-
-class ResponseMode(str, Enum):
-    direct_post = "direct_post"
-    direct_post_jwt = "direct_post.jwt"
-
-
-class ResponseSchema(BaseModel):
-    state: Optional[str]
-    nonce: str
-    vp_token: str
-    presentation_submission: PresentationSubmissionSchema
-
-    @field_validator("vp_token")
-    @classmethod
-    def _check_vp_token(cls, vp_token):
-        if is_jwt_format(vp_token):
-            return vp_token
-        else:
-            raise ValueError("vp_token is not in a JWT format.")
+@dataclass
+class AuthorizeResponsePayload:
+    """
+    AuthorizeResponsePayload is a simple schema class for
+        https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-response-parameters
+    only for the case when presentation submission is used over DCQL.
+    """
+    state: str
+    vp_token: str | list[str]
+    presentation_submission: dict

--- a/pyeudiw/openid4vp/schemas/response.py
+++ b/pyeudiw/openid4vp/schemas/response.py
@@ -1,6 +1,12 @@
 from dataclasses import dataclass
+from enum import Enum
 
 from pyeudiw.jwt.utils import is_jwe_format, is_jwt_format
+
+
+class ResponseMode(str, Enum):
+    direct_post = "direct_post"
+    direct_post_jwt = "direct_post.jwt"
 
 
 @dataclass

--- a/pyeudiw/openid4vp/schemas/response.py
+++ b/pyeudiw/openid4vp/schemas/response.py
@@ -1,10 +1,9 @@
-from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
 from pydantic import BaseModel, field_validator
 
-from pyeudiw.jwt.utils import is_jwe_format, is_jwt_format
+from pyeudiw.jwt.utils import is_jwt_format
 
 
 class DescriptorSchema(BaseModel):
@@ -37,25 +36,3 @@ class ResponseSchema(BaseModel):
             return vp_token
         else:
             raise ValueError("vp_token is not in a JWT format.")
-
-
-@dataclass
-class AuthorizeResponseDirectPostJwt:
-    response: str  # jwt
-
-    def __post_init__(self):
-        jwt = self.response
-        if not is_jwe_format(jwt) and not is_jwt_format(jwt):
-            raise ValueError(f"input response={jwt} is neither jwt not jwe format")
-
-
-@dataclass
-class AuthorizeResponsePayload:
-    """
-    AuthorizeResponsePayload is a simple schema class for
-        https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-response-parameters
-    only for the case when presentation submission is used over DCQL.
-    """
-    state: str
-    vp_token: str | list[str]
-    presentation_submission: dict

--- a/pyeudiw/tests/openid4vp/test_authorization_response.py
+++ b/pyeudiw/tests/openid4vp/test_authorization_response.py
@@ -1,0 +1,231 @@
+import pytest
+import satosa.context
+
+from pyeudiw.jwt.jwe_helper import JWEHelper
+from pyeudiw.openid4vp.authorization_response import DirectPostJwtJweParser, DirectPostParser
+from pyeudiw.openid4vp.exceptions import AuthRespParsingException, AuthRespValidationException
+
+
+@pytest.fixture
+def jwe_helper():
+    private_key = {
+        "kid": "DwR3tX_BuSwRrn3HjXom_ajjMGzu_15r_mJeG0HBilo",
+        "d": "UgwHyOMdyfF2dK6EjF6LX6Tyu0Ylha9SaaFgOBhjjRi1XW3FLy83iPRxCRHSHC-d3DMCZaK7wa0qDmok8KaVOhmL0V_LKcNaDaJHDxAynlWdnh8IJnlDOGuALeDAPiC5vCvVVkRcAo4F8KbOvaxkMZLPVqwlM5lYC31yD6aXPb3f6raNy-Jl9t1Jt_OYH9LobqgllZwu9S5qkXzBqfjCw4ymcu7VTi_P3dt141cja2eSZjG5bPORZ6Wy3gd9dQkLfdpjJXo5nSA1UC8cNpOLf8NZU659enPQ6nItyrt2Kx5aNwizD993TjrVuNloKUSI5DlNznh3JdDy_nWt7GyQr-tp_9l2Xma5heSix9Az8w1_0J3xUo4wK3hfe5-WD3HkYjeJyp9CqMNNKGR8LXz7KX_lUN2-U2hiodKKnf0y6NK9zhakgoox4kSfmOUTt0ir_4wWGqoAIh6QF1yfXkVsdJ7LyMTdu2B54Kv4M41g98ifP2UjKicreCW3Lw--KmJJ",
+        "e": "AQAB",
+        "kty": "RSA",
+        "n": "vxPbeX_PgRI5mpOoANQkC1HU09LZePPygjaUtrXrZkx0rhK-2LaoNLns5EoBkJOuj8JrHU_W2UOZBIE-tpLJ8UUSuJNXNZhrWqezhjO0aIue_JgyMWjp2IZ_BofyhrMenqYI6oA8B9eKdD-1zxF0vflCHylq7vdYcKKPZcr0QjyVTltuEbRiS8WHjFV5_sWuYJkDt-5bXW4ZapDV4NG2OcwcRROR5gwU1EhWX-kQbNPw84wZpEGXy5fFTaosfUVbvKSXP_d8IZ4fizqMi69bk6IjLqfw3JZcIKnzz7ou302dq2sIH_R1gQHNJ6b-oTh5nq3JLCMViGHZAH0sIMu6eiLzvcADX5PpbMO9Y83l-UbMEqH0iv7wtW3gVE7OjolZCiFXwhhntWj5ccomlzgYFreebRevQItHZUxiN7n7tJMOWouV1LHecWfixHbweaBFooGSzY9hlFvERKmbfPqNaIce8PHd-dDWw9Yxq5RdNpcMQKm5ruYlV3pWGxoQaHdX",
+        "p": "zxOeQgvnCZzIIsZoz18ROo8fCRZT7K6h4uvz6fvTz6e_6TKWUYohjsBfYAkbNgJamkxdSJyaQWDMPs0mIG2j2IcpqG0JJGQ68QCqai8H-o-_wb0hjp3fY6TofVaEzFvQiOJE2ZyqtSn7hDrEFEmceJB_VzIvOZbS-AZo9--R2PTQ4h7CurkWKCOKAbeBfOWEX_s6UOaLQzMYDykiHSlPQmF9BZAsaoRHXdZLlsgxgQ3nbPbsBx2d1axlIIhb7Xkl",
+        "q": "7DiV8cgKFnOGCTHT3cr_8xIKwD0LoWnGibqdA2p0XSQTXTLUr532DKK_3YMdm0F0YtCyPQBbsJoLspbnK6yTo3RPFr0zooJ5eCYnLO_qOBYFwYbOhhXrYPjfpEDSXls9BD6cHhCCQtiNAADIjaMpmoEexPD6lMoijTF7qzEst2fszvYTToczroWHPe8RuJR7J_FEM-soD99ERqJanj5BUs-ruuNwshM_Fp7C-ubt9PbMo9gv5p9nrsT8oAI7wJvL",
+        "use": "enc"
+    }
+    jwe_helper = JWEHelper(private_key)
+    return jwe_helper
+
+
+def test_direct_post_parser_good_case():
+    parser = DirectPostParser()
+
+    ctx = satosa.context.Context()
+    ctx.request_method = "POST"
+    vp_token = "qwe.rty.uio~asd.fgh.jkl"
+    state = "123456"
+    presentation_submission = {
+        "id": "submit-id",
+        "definition_id": "definition-id",
+        "descriptor_map": [
+            {
+                "id": "verifiable-credential-type",
+                "format": "dc+sd-jwt",
+                "path": "$.vct"
+            }
+        ]
+    }
+    ctx.request = {
+        "vp_token": vp_token,
+        "state": state,
+        "presentation_submission": presentation_submission
+    }
+
+    resp = parser.parse_and_validate(ctx)
+    assert resp.vp_token == vp_token
+    assert resp.state == state
+    assert resp.presentation_submission == presentation_submission
+
+
+def test_direct_post_response_bad_parse_case():
+    # case 0: bad method
+    parser = DirectPostParser()
+
+    ctx = satosa.context.Context()
+    ctx.request_method = "GET"
+    vp_token = "qwe.rty.uio~asd.fgh.jkl"
+    state = "123456"
+    presentation_submission = {
+        "id": "submit-id",
+        "definition_id": "definition-id",
+        "descriptor_map": [
+            {
+                "id": "verifiable-credential-type",
+                "format": "dc+sd-jwt",
+                "path": "$.vct"
+            }
+        ]
+    }
+    ctx.qs_params = {
+        "vp_token": vp_token,
+        "state": state,
+        "presentation_submission": presentation_submission
+    }
+
+    try:
+        parser.parse_and_validate(ctx)
+        assert False, "accepted a GET request when only POST can be accepted"
+    except AuthRespParsingException:
+        assert True
+    except AuthRespValidationException as e:
+        assert False, f"obtained unexpected validation exception: {e}"
+
+    # case 1: bad shape
+    ctx = satosa.context.Context()
+    ctx.request_method = "POST"
+    ctx.request = {
+        "bad_param_name": "bad parameter value",
+    }
+
+    try:
+        parser.parse_and_validate(ctx)
+        assert False, "accepted an direct post with invalid parameters"
+    except AuthRespParsingException:
+        assert True
+    except AuthRespValidationException as e:
+        assert False, f"obtained unexpected validation exception: {e}"
+
+
+def test_direct_post_jwt_jwe_parser_good_case(jwe_helper):
+
+    parser = DirectPostJwtJweParser(jwe_helper)
+
+    ctx = satosa.context.Context()
+    ctx.request_method = "POST"
+    vp_token = "qwe.rty.uio~asd.fgh.jkl"
+    state = "123456"
+    presentation_submission = {
+        "id": "submit-id",
+        "definition_id": "definition-id",
+        "descriptor_map": [
+            {
+                "id": "verifiable-credential-type",
+                "format": "dc+sd-jwt",
+                "path": "$.vct"
+            }
+        ]
+    }
+    data = {
+        "vp_token": vp_token,
+        "state": state,
+        "presentation_submission": presentation_submission
+    }
+    ctx.request = {
+        "response": jwe_helper.encrypt(data)
+    }
+
+    resp = parser.parse_and_validate(ctx)
+    assert resp.vp_token == vp_token
+    assert resp.state == state
+    assert resp.presentation_submission == presentation_submission
+
+
+def test_direct_post_jwt_jwe_parser_bad_parse_case(jwe_helper):
+    # case 0: bad method
+    parser = DirectPostJwtJweParser(jwe_helper)
+
+    ctx = satosa.context.Context()
+    ctx.request_method = "GET"
+    vp_token = "qwe.rty.uio~asd.fgh.jkl"
+    state = "123456"
+    presentation_submission = {
+        "id": "submit-id",
+        "definition_id": "definition-id",
+        "descriptor_map": [
+            {
+                "id": "verifiable-credential-type",
+                "format": "dc+sd-jwt",
+                "path": "$.vct"
+            }
+        ]
+    }
+    ctx.qs_params = {
+        "response": jwe_helper.encrypt({
+            "vp_token": vp_token,
+            "state": state,
+            "presentation_submission": presentation_submission
+        })
+    }
+
+    try:
+        parser.parse_and_validate(ctx)
+        assert False, "accepted a GET request when only POST can be accepted"
+    except AuthRespParsingException:
+        assert True
+    except AuthRespValidationException as e:
+        assert False, f"obtained unexpected validation exception: {e}"
+
+    # case 1: bad shape
+    ctx = satosa.context.Context()
+    ctx.request_method = "POST"
+    ctx.request = {
+        "response": jwe_helper.encrypt({"bad_param_name": "bad parameter value"}),
+    }
+
+    try:
+        parser.parse_and_validate(ctx)
+        assert False, "accepted an direct post with invalid parameters"
+    except AuthRespParsingException:
+        assert True
+    except AuthRespValidationException as e:
+        assert False, f"obtained unexpected validation exception: {e}"
+
+
+def test_direct_post_jwt_jwe_parser_bad_validation_case(jwe_helper):
+    parser = DirectPostJwtJweParser(jwe_helper)
+
+    wrong_public_key = {
+        "kid": "ybmSufrnl3Cu6OrNcsOF_g95g5zShf2aKpg59PMcMm8",
+        "e": "AQAB",
+        "kty": "RSA",
+        "n": "sCLDmvDKr4y7EHLf4TbjNqa3_p4GnTLqPXdvi0ce2BW2NIK1vYtz9uk8oIlResIWJk1T59LAS8YGF5BLkjLLSyMjrhHySoyRDrBEk_cz-F3Mabc7x-5GDAbxvFDZKQ2n5UVQUWgboFISGp2zpmrYzvewv2WCxZ4a3mS6kwAvjl_S9kahD-SFjiNyHsSaA0lDrF5xQpT2MaMha0dPwgNrChCcG4TTG5YBy4zgktlfA9GRnrEKUJioiKYapMAotziNRBoH128CJGAdMxaO5SVYC0PVLnmKd3cv4bPqGYMRszI6x3i5YUTLk8HwWPL9SUV25pAFp_nDRlgQTdvxssClhZ8VbMZQ3x2I738ixGud_1ggBVFTGDDGDQem4jOz6AsPBVrwtwWStVpA5V5FyEhbgZmE7Orb0cNsmIBjVIPBuFtLBmSELAiJ_WK7ajo3xKtIMTFB-JVX1PVawZOkUzS94BnJ0i7RGc4uzZBhhiOWxBHQGIFhfJnD1OggXnHkVYRn",
+        "use": "enc"
+    }
+    wrong_helper = JWEHelper(wrong_public_key)
+
+    ctx = satosa.context.Context()
+    ctx.request_method = "POST"
+    vp_token = "qwe.rty.uio~asd.fgh.jkl"
+    state = "123456"
+    presentation_submission = {
+        "id": "submit-id",
+        "definition_id": "definition-id",
+        "descriptor_map": [
+            {
+                "id": "verifiable-credential-type",
+                "format": "dc+sd-jwt",
+                "path": "$.vct"
+            }
+        ]
+    }
+    data = {
+        "vp_token": vp_token,
+        "state": state,
+        "presentation_submission": presentation_submission
+    }
+    ctx.request = {
+        "response": wrong_helper.encrypt(data)
+    }
+
+    try:
+        parser.parse_and_validate(ctx)
+        assert False, "accepted an direct post with wrong encryption"
+    except AuthRespParsingException as e:
+        assert False, f"obtained unexpected parsing exception: {e}"
+    except AuthRespValidationException:
+        assert True


### PR DESCRIPTION
This PR closes #310

It introduces a new, very, very small asbtraction layer called `AuthorizationResponseParser` in the response handler that can process either direct_post responses or direct_post.jwt responses.

The current implementation is mean to be an extension of the current solution. In particular, like the current solution, the parsed content expects to find a `presentation_submission` and **is not ready to be extended with future DCQL support**.
When  DCQL will be supported, the interface definition `AuthorizationResponseParser` will likely have to be updated.
I decided to to preserve the "non compliance" with DCQL in order to isolate future code changes that will be result of that feature.