### PR TITLE
Non conformant url requests

### DIFF
--- a/pyeudiw/trust/handler/_direct_trust_jwk.py
+++ b/pyeudiw/trust/handler/_direct_trust_jwk.py
@@ -208,12 +208,12 @@ class _DirectTrustJwkHandler(TrustHandlerInterface, BaseLogger):
         return trust_source
 
 
-def build_jwk_issuer_endpoint(issuer_id: str, endpoint_component: str) -> str:
+def build_jwk_issuer_endpoint(issuer_id: str, endpoint_component: str, conform: bool = True) -> str:
     if not endpoint_component:
         return issuer_id
 
     issuer_id = f"https://{issuer_id.strip('/')}" if not issuer_id.startswith("http") else issuer_id
 
     baseurl = urlparse(issuer_id)
-    full_endpoint_path = f"/{endpoint_component.strip('/')}{baseurl.path}"
+    full_endpoint_path = f"/{endpoint_component.strip('/')}{baseurl.path}" if conform else f"{baseurl.path}/{endpoint_component.strip('/')}"
     return baseurl._replace(path=full_endpoint_path).geturl()

--- a/pyeudiw/trust/handler/_direct_trust_jwk.py
+++ b/pyeudiw/trust/handler/_direct_trust_jwk.py
@@ -211,6 +211,9 @@ class _DirectTrustJwkHandler(TrustHandlerInterface, BaseLogger):
 def build_jwk_issuer_endpoint(issuer_id: str, endpoint_component: str) -> str:
     if not endpoint_component:
         return issuer_id
+
+    issuer_id = f"https://{issuer_id.strip('/')}" if not issuer_id.startswith("http") else issuer_id
+
     baseurl = urlparse(issuer_id)
     full_endpoint_path = f"/{endpoint_component.strip('/')}{baseurl.path}"
     return baseurl._replace(path=full_endpoint_path).geturl()

--- a/pyeudiw/trust/handler/_direct_trust_jwk.py
+++ b/pyeudiw/trust/handler/_direct_trust_jwk.py
@@ -100,11 +100,8 @@ class _DirectTrustJwkHandler(TrustHandlerInterface, BaseLogger):
             # get jwks by value
             return jwks
         return self._get_jwks_by_reference(jwks_uri)
-
-    def _get_jwk_metadata(self, issuer_id: str) -> dict:
-        if not self.jwk_endpoint:
-            return {}
-        endpoint = build_jwk_issuer_endpoint(issuer_id, self.jwk_endpoint)
+    
+    def _get_url(self, endpoint: str) -> str:
         if self.cache_ttl:
             resp = cacheable_get_http_url(
                 self.cache_ttl,
@@ -116,11 +113,27 @@ class _DirectTrustJwkHandler(TrustHandlerInterface, BaseLogger):
             resp = get_http_url(
                 [endpoint], self.httpc_params, http_async=self.http_async_calls
             )[0]
-        if (not resp) or (resp.status_code != 200):
-            raise InvalidJwkMetadataException(
-                f"failed to fetch valid jwk metadata: obtained {resp}"
-            )
-        return resp.json()
+
+        return resp
+
+    def _get_jwk_metadata(self, issuer_id: str) -> dict:
+        if not self.jwk_endpoint:
+            return {}
+        
+        endpoints = [
+            build_jwk_issuer_endpoint(issuer_id, self.jwk_endpoint),
+            build_jwk_issuer_endpoint(issuer_id, self.jwk_endpoint, conform=False),
+        ]
+
+        for endpoint in endpoints:
+            resp = self._get_url(endpoint)
+
+            if resp and resp.status_code == 200:
+                return resp.json()
+
+        raise InvalidJwkMetadataException(
+            f"failed to fetch valid jwk metadata: obtained {resp}"
+        )
 
     def _get_jwks_by_reference(self, jwks_reference_uri: str) -> dict:
         """


### PR DESCRIPTION
Fix #357 

FYI:
Commit [06798d4](https://github.com/italia/eudi-wallet-it-python/pull/374/commits/06798d43e8771eed8191dbdc972a502717cccf9f) resolves a bug where if no protocol is provided the the parsing results in a only path component with the consequent return value, assuming that the url component is 4d2d5e12-4123-475f-8fa9-807d46df324f.issuer.it, in:

/.well-known/jwt-vc-issuer4d2d5e12-4123-475f-8fa9-807d46df324f.issuer.it

I've added https as fallback for this reason. 