### PR TITLE
feat: authorization error response

### DIFF
--- a/example/satosa/integration_test/commons.py
+++ b/example/satosa/integration_test/commons.py
@@ -1,18 +1,21 @@
 import base64
 from copy import deepcopy
-import json
-from urllib.parse import urlparse
-from pyeudiw.tools.utils import exp_from_now, iat_now
-from bs4 import BeautifulSoup
 import datetime
+from io import StringIO
+import json
 import requests
 from typing import Any, Literal
+import urllib.parse
 
-from io import StringIO
+from bs4 import BeautifulSoup
+from playwright.sync_api import Playwright, Page
+
+
 from pyeudiw.jwk import JWK
 from pyeudiw.jwt.jwe_helper import JWEHelper
 from pyeudiw.jwt.jws_helper import DEFAULT_SIG_KTY_MAP, JWSHelper
 from pyeudiw.jwt.utils import decode_jwt_payload
+from pyeudiw.sd_jwt.holder import SDJWTHolder
 from pyeudiw.sd_jwt.issuer import SDJWTIssuer
 from pyeudiw.sd_jwt.utils.yaml_specification import _yaml_load_specification
 from pyeudiw.storage.base_storage import TrustType
@@ -28,12 +31,12 @@ from pyeudiw.tests.federation.base import (
     leaf_wallet_jwk,
     leaf_wallet_signed,
 )
-from pyeudiw.sd_jwt.holder import SDJWTHolder
+from pyeudiw.tools.utils import exp_from_now, iat_now
 from pyeudiw.trust.model.trust_source import TrustSourceData
 
-from . saml2_sp import saml2_request
+from saml2_sp import saml2_request
 
-from . settings import (
+from settings import (
     IDP_BASEURL,
     CONFIG_DB,
     RP_EID,
@@ -51,6 +54,7 @@ ISSUER_CONF = {
             country: "IT"
             locality: "Rome"
         !sd tax_id_code: "TINIT-XXXXXXXXXXXXXXXX"
+        !sd vct: "urn:eu.europa.ec.eudi:por:1"
     """,
     "issuer": leaf_cred['sub'],
     "default_exp": 1024,
@@ -71,6 +75,8 @@ CREDENTIAL_ISSUER_TRUST_SOURCE_Dict = {
 CREDENTIAL_ISSUER_TRUST_SOURCE = TrustSourceData(**CREDENTIAL_ISSUER_TRUST_SOURCE_Dict)
 WALLET_PRIVATE_JWK = JWK(leaf_wallet_jwk.serialize(private=True))
 WALLET_PUBLIC_JWK = JWK(leaf_wallet_jwk.serialize())
+
+STATUS_ENDPOINT_URI_JS = "statusEndpoint()+'?id='+sessionIdentifier()"  # javascript functions that yield the status URI; defined in qrcode.html
 
 
 def setup_test_db_engine() -> DBEngine:
@@ -125,7 +131,7 @@ def create_issuer_test_data() -> dict[Literal["jws"] | Literal["issuance"], str]
     # create a SD-JWT signed by a trusted credential issuer
     settings = ISSUER_CONF
     settings["default_exp"] = 33
-    
+
     user_claims = _yaml_load_specification(StringIO(settings["sd_specification"]))
     claims = {
         "iss": settings["issuer"],
@@ -182,30 +188,36 @@ def create_authorize_response(vp_token: str, state: str, response_uri: str) -> s
     ).content.decode()
     rp_ec = decode_jwt_payload(rp_ec_jwt)
 
-    #  assert response_uri == rp_ec["metadata"]["openid_credential_verifier"]["response_uris"][0]
     encryption_key = rp_ec["metadata"]["openid_credential_verifier"]["jwks"]["keys"][1]
 
     response = {
         "state": state,
         "vp_token": vp_token,
         "presentation_submission": {
-            "definition_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+            "definition_id": "global-presentation-definition-id ",
             "id": "04a98be3-7fb0-4cf5-af9a-31579c8b0e7d",
             "descriptor_map": [
                 {
-                    "id": "pid-sd-jwt:unique_id+given_name+family_name",
-                    "path": "$.vp_token.verified_claims.claims._sd[0]",
+                    "id": "another-input-specific-id",
+                    "path": "$[0]",
                     "format": "dc+sd-jwt"
-                }
+                },
             ],
             "aud": response_uri
         }
     }
     encrypted_response = JWEHelper(
-        # RSA (EC is not fully supported to date)
         JWK(encryption_key).as_dict()
     ).encrypt(response)
     return encrypted_response
+
+
+def create_authorize_error_response_user_denies(state: str) -> dict:
+    return {
+        "error": "access_denied",
+        "error_description": "The End-User did not give consent to share the requested Credentials with the Verifier",
+        "state": state
+    }
 
 
 def extract_saml_attributes(saml_response: str) -> set[Any]:
@@ -227,3 +239,48 @@ def verify_request_object_jwt(ro: str, client: requests.Session):
     metadata = json.loads(metadata_raw)
     verifier = JWSHelper(metadata["jwks"]["keys"])
     verifier.verify(ro)
+
+
+def verify_status_login_page(login_page: Page, expected_code: int):
+    """
+    verify_status_login_page invokes the status endpoind though the javascript
+    method that pools the very same endpoint.
+    """
+    current_status = login_page.evaluate(
+        f"fetch({STATUS_ENDPOINT_URI_JS}).then(resp => resp.status)"
+    )
+    assert expected_code == current_status
+
+
+def extract_request_uri_login_page(page_content: str) -> str:
+    """
+    extract_request_uri_login_page parses the QR code in the login page
+    and returns the request_uri field embedded in the QR code value.
+    """
+    bs = BeautifulSoup(page_content, features="html.parser")
+    # Request URI is extracted by parsing the QR code in the response page
+    qrcode_element = list(bs.find(id="content-qrcode-payload").children)[1]
+    qrcode_text = qrcode_element.get("contents")
+    request_uri = urllib.parse.parse_qs(qrcode_text)["request_uri"][0]
+    return request_uri
+
+
+def extract_content_title_login_page(page_content: str) -> str:
+    bs = BeautifulSoup(page_content, features="html.parser")
+    content_title_element = list(bs.find(id="content-title").children)[0]
+    return content_title_element
+
+
+def get_new_browser_page(playwright: Playwright) -> Page:
+    """
+    Returns a browser page that live in a browser instance that is fresh and
+    does not share cookies and cache with other browser instances
+    """
+    webkit = playwright.webkit
+    rp_browser = webkit.launch(timeout=0)
+    rp_context = rp_browser.new_context(
+        ignore_https_errors=True,  # required as otherwise self-signed certificates are not accepted,
+        java_script_enabled=True,
+        user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36"
+    )
+    return rp_context.new_page()

--- a/example/satosa/integration_test/cross_device_integration_test.py
+++ b/example/satosa/integration_test/cross_device_integration_test.py
@@ -7,7 +7,7 @@ from playwright.sync_api import sync_playwright, Playwright, Page
 
 from pyeudiw.jwt.utils import decode_jwt_payload
 
-from . commons import (
+from commons import (
     ISSUER_CONF,
     setup_test_db_engine,
     apply_trust_settings,
@@ -18,7 +18,7 @@ from . commons import (
     extract_saml_attributes,
     verify_request_object_jwt
 )
-from . settings import TIMEOUT_S
+from settings import TIMEOUT_S
 
 # put a trust attestation related itself into the storage
 # this is then used as trust_chain header parameter in the signed request object

--- a/example/satosa/integration_test/cross_device_integration_test.py
+++ b/example/satosa/integration_test/cross_device_integration_test.py
@@ -1,3 +1,16 @@
+# This file defines an end-to-end integration test flow without Duckle support.
+#
+# To run this integration test, you need to modify the `pyeudiw_backend.yaml` configuration file
+# by adding the following entries:
+#   config.duckle.dcql_query
+#
+# Additionally, you must remove the Duckle handler in the `credential_presentation_handlers` section:
+#
+# credential_presentation_handlers: [...]
+#   - module: pyeudiw.duckle_ql.handler
+#     class: DuckleHandler
+#     format: jwt_vc_json
+
 import time
 import requests
 import urllib.parse

--- a/example/satosa/integration_test/same_device_integration_test.py
+++ b/example/satosa/integration_test/same_device_integration_test.py
@@ -1,3 +1,16 @@
+# This file defines an end-to-end integration test flow without Duckle support.
+#
+# To run this integration test, you need to modify the `pyeudiw_backend.yaml` configuration file
+# by adding the following entries:
+#   config.duckle.dcql_query
+#
+# Additionally, you must remove the Duckle handler in the `credential_presentation_handlers` section:
+#
+# credential_presentation_handlers: [...]
+#   - module: pyeudiw.duckle_ql.handler
+#     class: DuckleHandler
+#     format: jwt_vc_json
+
 import re
 import requests
 import urllib.parse

--- a/example/satosa/integration_test/same_device_integration_test.py
+++ b/example/satosa/integration_test/same_device_integration_test.py
@@ -4,7 +4,7 @@ import urllib.parse
 
 from pyeudiw.jwt.utils import decode_jwt_payload
 
-from . commons import (
+from commons import (
     ISSUER_CONF,
     setup_test_db_engine,
     apply_trust_settings,
@@ -15,7 +15,7 @@ from . commons import (
     extract_saml_attributes,
     verify_request_object_jwt
 )
-from . settings import TIMEOUT_S
+from settings import TIMEOUT_S
 
 # put a trust attestation related itself into the storage
 # this is then used as trust_chain header parameter in the signed request object

--- a/example/satosa/integration_test/same_device_integration_test_duckle.py
+++ b/example/satosa/integration_test/same_device_integration_test_duckle.py
@@ -1,49 +1,4 @@
 # This file defines an end-to-end integration test flow for Duckle support.
-#
-# To run this integration test, you need to modify the `pyeudiw_backend.yaml` configuration file
-# by adding the following entries:
-#
-# config:
-#   duckle:
-#     dcql_query: >
-#       {
-#         "credentials": [
-#           {
-#             "id": "personal id data",
-#             "format": "dc+sd-jwt",
-#             "meta": {
-#               "vct_values": [
-#                 "https://trust-registry.eid-wallet.example.it/credentials/v1.0/personidentificationdata"
-#               ]
-#             },
-#             "claims": [
-#               { "path": ["given_name"] },
-#               { "path": ["family_name"] }
-#             ]
-#           },
-#           {
-#             "id": "wallet attestation",
-#             "format": "dc+sd-jwt",
-#             "meta": {
-#               "vct_values": [
-#                 "https://itwallet.registry.example.it/WalletAttestation"
-#               ]
-#             },
-#             "claims": [
-#               { "path": ["wallet_link"] },
-#               { "path": ["wallet_name"] }
-#             ]
-#           }
-#         ]
-#       }
-#
-# Additionally, you must register the Duckle handler in the `credential_presentation_handlers` section:
-#
-# credential_presentation_handlers: [...]
-#   - module: pyeudiw.duckle_ql.handler
-#     class: DuckleHandler
-#     format: jwt_vc_json
-
 
 import re
 import urllib.parse

--- a/example/satosa/integration_test/same_device_integration_test_duckle.py
+++ b/example/satosa/integration_test/same_device_integration_test_duckle.py
@@ -1,3 +1,50 @@
+# This file defines an end-to-end integration test flow for Duckle support.
+#
+# To run this integration test, you need to modify the `pyeudiw_backend.yaml` configuration file
+# by adding the following entries:
+#
+# config:
+#   duckle:
+#     dcql_query: >
+#       {
+#         "credentials": [
+#           {
+#             "id": "personal id data",
+#             "format": "dc+sd-jwt",
+#             "meta": {
+#               "vct_values": [
+#                 "https://trust-registry.eid-wallet.example.it/credentials/v1.0/personidentificationdata"
+#               ]
+#             },
+#             "claims": [
+#               { "path": ["given_name"] },
+#               { "path": ["family_name"] }
+#             ]
+#           },
+#           {
+#             "id": "wallet attestation",
+#             "format": "dc+sd-jwt",
+#             "meta": {
+#               "vct_values": [
+#                 "https://itwallet.registry.example.it/WalletAttestation"
+#               ]
+#             },
+#             "claims": [
+#               { "path": ["wallet_link"] },
+#               { "path": ["wallet_name"] }
+#             ]
+#           }
+#         ]
+#       }
+#
+# Additionally, you must register the Duckle handler in the `credential_presentation_handlers` section:
+#
+# credential_presentation_handlers: [...]
+#   - module: pyeudiw.duckle_ql.handler
+#     class: DuckleHandler
+#     format: jwt_vc_json
+
+
 import re
 import urllib.parse
 

--- a/example/satosa/integration_test/testconfig/potential/wp2uc1/userdenies/pyeudiw_backend.yaml
+++ b/example/satosa/integration_test/testconfig/potential/wp2uc1/userdenies/pyeudiw_backend.yaml
@@ -1,0 +1,381 @@
+module: pyeudiw.satosa.backend.OpenID4VPBackend
+name: OpenID4VP
+
+config:
+
+  ui:
+    static_storage_url: !ENV SATOSA_BASE_STATIC
+    template_folder: "templates" # project root
+    qrcode_template: "qr_code.html"
+    error_template: "error.html"
+    error_url: "https://localhost/error_page.html"
+    authorization_error_template: "authorization_error.html"
+  
+  endpoints:
+    pre_request: '/pre-request'
+    request:
+      module: pyeudiw.satosa.default.request_handler
+      class: RequestHandler
+      path: '/request-uri'
+    response:
+      module: pyeudiw.satosa.default.response_handler
+      class: ResponseHandler
+      path: '/response-uri'
+    status: '/status'
+    get_response: '/get-response'
+
+  qrcode:
+    size: 250 # px
+    color: '#000000'  # hex
+    expiration_time: 120 # seconds
+    logo_path: 'wallet-it/wallet-icon-blue.svg' # relative to static_storage_url
+
+  response_code:
+    sym_key: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef" # hex string of 64 characters
+
+  jwt:
+    default_sig_alg: ES256 # or RS256. Please note that this signature alg MUST be compliant with the private keys used for the signature. X.509 certificates MUST be therefore ECDSA using ES, and RSA using RS
+    default_enc_alg: RSA-OAEP
+    default_enc_enc: A256CBC-HS512
+    default_exp: 6         # minutes
+    enc_alg_supported: &enc_alg_supported
+        - RSA-OAEP
+        - RSA-OAEP-256
+        - ECDH-ES
+        - ECDH-ES+A128KW
+        - ECDH-ES+A192KW
+        - ECDH-ES+A256KW
+    enc_enc_supported: &enc_enc_supported
+        - A128CBC-HS256
+        - A192CBC-HS384
+        - A256CBC-HS512
+        - A128GCM
+        - A192GCM
+        - A256GCM
+    sig_alg_supported: &sig_alg_supported
+        - RS256
+        - RS384
+        - RS512
+        - ES256
+        - ES384
+        - ES512
+    
+  authorization:
+    client_id: # this field if not set will be autopopulated using internal variables base_url and name using the following format: "<base_url>/<name>" 
+    auth_iss_id: # this field if not set will be set to client_id in the authz request 
+    url_scheme: haip
+    scopes:
+    - pid-sd-jwt:unique_id+given_name+family_name
+    default_acr_value: https://www.spid.gov.it/SpidL2
+    expiration_time: 5 # minutes
+    aud: https://self-issued.me/v2
+    response_mode: direct_post
+    presentation_definition:
+      id: global-presentation-definition-id
+      input_descriptors:
+      - id: input-specific-id
+        purpose: Request presentation holding Power of Representation attestation
+        format:
+          dc+sd-jwt: {}
+        constraints:
+          fields:
+          - path:
+            - "$.vct"
+            filter:
+              const: urn:eu.europa.ec.eudi:por:1
+      - id: another-input-specific-id
+        purpose: Request first name and last name claims from PID attestation
+        format:
+          dc+sd-jwt: {}
+        constraints:
+          limit_disclosure: required
+          fields:
+            - path:
+              - "$.vct"
+              filter:
+                type: string
+                pattern: urn:eu.europa.ec.eudi:por:1
+            - path:
+              - "$.family_name"
+            - path:
+              - "$.given_name"
+
+  user_attributes:
+    unique_identifiers:
+    - tax_id_code
+    - unique_id
+    subject_id_random_value: CHANGEME!
+  
+  network:
+    httpc_params: &httpc_params
+      connection:
+        ssl: true
+      session:
+        timeout: 6
+
+  # private jwk
+  metadata_jwks: &metadata_jwks
+    - crv: P-256 # Please note: this is the first key [0] and it is used for signing the presentation requests
+      d: KzQBowMMoPmSZe7G8QsdEWc1IvR2nsgE8qTOYmMcLtc
+      kid: dDwPWXz5sCtczj7CJbqgPGJ2qQ83gZ9Sfs-tJyULi6s
+      use: sig
+      kty: EC
+      x: TSO-KOqdnUj5SUuasdlRB2VVFSqtJOxuR5GftUTuBdk
+      y: ByWgQt1wGBSnF56jQqLdoO1xKUynMY-BHIDB3eXlR7
+    - kty: RSA
+      d: QUZsh1NqvpueootsdSjFQz-BUvxwd3Qnzm5qNb-WeOsvt3rWMEv0Q8CZrla2tndHTJhwioo1U4NuQey7znijhZ177bUwPPxSW1r68dEnL2U74nKwwoYeeMdEXnUfZSPxzs7nY6b7vtyCoA-AjiVYFOlgKNAItspv1HxeyGCLhLYhKvS_YoTdAeLuegETU5D6K1xGQIuw0nS13Icjz79Y8jC10TX4FdZwdX-NmuIEDP5-s95V9DMENtVqJAVE3L-wO-NdDilyjyOmAbntgsCzYVGH9U3W_djh4t3qVFCv3r0S-DA2FD3THvlrFi655L0QHR3gu_Fbj3b9Ybtajpue_Q
+      e: AQAB
+      use: enc
+      kid: 9Cquk0X-fNPSdePQIgQcQZtD6J0IjIRrFigW2PPK_-w
+      n: utqtxbs-jnK0cPsV7aRkkZKA9t4S-WSZa3nCZtYIKDpgLnR_qcpeF0diJZvKOqXmj2cXaKFUE-8uHKAHo7BL7T-Rj2x3vGESh7SG1pE0thDGlXj4yNsg0qNvCXtk703L2H3i1UXwx6nq1uFxD2EcOE4a6qDYBI16Zl71TUZktJwmOejoHl16CPWqDLGo9GUSk_MmHOV20m4wXWkB4qbvpWVY8H6b2a0rB1B1YPOs5ZLYarSYZgjDEg6DMtZ4NgiwZ-4N1aaLwyO-GLwt9Vf-NBKwoxeRyD3zWE2FXRFBbhKGksMrCGnFDsNl5JTlPjaM3kYyImE941ggcuc495m-Fw
+      p: 2zmGXIMCEHPphw778YjVTar1eycih6fFSJ4I4bl1iq167GqO0PjlOx6CZ1-OdBTVU7HfrYRiUK_BnGRdPDn-DQghwwkB79ZdHWL14wXnpB5y-boHz_LxvjsEqXtuQYcIkidOGaMG68XNT1nM4F9a8UKFr5hHYT5_UIQSwsxlRQ0
+      q: 2jMFt2iFrdaYabdXuB4QMboVjPvbLA-IVb6_0hSG_-EueGBvgcBxdFGIZaG6kqHqlB7qMsSzdptU0vn6IgmCZnX-Hlt6c5X7JB_q91PZMLTO01pbZ2Bk58GloalCHnw_mjPh0YPviH5jGoWM5RHyl_HDDMI-UeLkzP7ImxGizrM
+    - kty: RSA
+      use: sig
+      alg: RS256
+      kid: m00NPAelNBnG_wK2R5EpI_k-GWCHEUySamQYubgFjCg
+      d: nMsnqz0lPHNGBgUqyuJ5nXQ0jh-mzs6d2xOY_QhpkRW1kEbexRJDdVV3fqMxj_s0MiF8mn-s8ea3e8cbNDgIy000Wvx05y1rMkB6KaZX2ZL5jwU7i_xP6NlLh8itikqJz7kKQSILgibQFFQDcScpEk8gUKa6fmSJQVwTII6GoJCdiJflv-FI2OQ_TCBQEEVVLpeUiVSP0n3OMUKGBlbaHOQkArUpla_ke_mtdfIrl7uB74Rxrin68KtFHkGDGdJPs-PPO1yJ2paFZI9QR_ettZ22v45c-qIgmCjsEnITDMaO9724PU_umlWsWe36Y9RAAzofKsjKqvA1OIzU03ob9Q
+      n: sP6jt1XwJE0JDKxy4B7r3Jdb8W6bSRoVunyjWMgl5IafqFwHsJlYgCAWPeTrAL-iyjdnWC1csHuTqWjdndDL-oqEarrqoDAycVkfFTUTD81_wVhWUzAwxhQHiT7PTUIsV7m9VGlfC_kdCpQl5CcK1yx2nQ1KbqWOV1_5WnMgnN_EpNmztkZDnJmKedVduOb2dKWwnLS3fcGvUxXc87DjAzC2vfgQSoQfXAZbwItyS6OinFiUnBxRvt9ZY2IapjI1-wwDKKeRrqPC-fV2oWTrMqoYAvIDnf9AjKHAbIw7q301-7-eaUMF1hVtAz1XeXvMp0wK8_uSo9Vgv1vHhBpOwQ
+      e: AQAB
+      p: 0ViKTSyZdLtvbLBpTvVAXTdrhTwGXuh16PadQMAVmkoxOPiExRB5uLiy2ADaVKSglia5aQBUp9v0ygEEOmkiUtn5A26D9ui0dkPR0hx4fwqCOOmA2ZyDUNFJ_qrGSwT1SxGQDHeRteymJG7uN9QekS3XiBDgFJxwl-vVpoSTBJM
+      q: 2HBr9qhVd3zZUQuNb7ro06ErLl4fhL-DiKsNqXB772tDNTJYeog1nOWgS22tcv5WHrSoYF1x5Q74YVoA6yVj6DwFx2Hc2pYZazzhYMRC3NAWkTEdroy9IjtpzKIpQIqw-sq8CbWVBXzho8uQBCdg8h73z11_HPyXT9BqQCmxJ9s
+      dp: WsQ32rQuqNUnv4lRb4GYcZI41SCsZnQFw4dBsTRXaXknlFr0PfkhvXyfVlYwU6i5U8DgfO0-xzTwErGUIrs4vZFyjRFauDA3JlvLWn0rpXFp-sELM87PhLfpjDiBFz_EFtM7kJw7GhTMCFnsgVpAEpQ8sesXLPiTPNts2_D5SW8
+      dq: jWlucLrtFGOjDRuyLjT9l__uWZ4vk6kZRHsWMwWGRBhd0ezx-CT0em1hPMcNE1vvYqKAfG2xU4pjaB_JB9nnG73TvMBI7xwwwWsGihXQ5bqjc_uWPAxCKpKM_qFYuI2lMkaxctqL4gkE1-LRVpVv9uGa4YZh3ct_BSvTr9ZNpA8
+      qi: kn9Etj4a2erCUmoZUQalPjHxCRYm5Q3wAkFIRGSQADA51mkwQHyTYqXbHcmXn2ZgXBVI6XDWJB51Me-NCPfITTlusqxvATF7Q-QJtdK_FbgNtcVRNc1FMq_M7VBHA1i9wJR7T4t57aywfXPmlsA5TToTDRe-ybdw0C3ys4KQATs
+
+  #This is the configuration for the relaying party metadata
+  metadata: &metadata
+    application_type: web
+
+    #The following section contains all the algorithms supported for the encryption of response
+    authorization_encrypted_response_alg: *enc_alg_supported
+    authorization_encrypted_response_enc: *enc_enc_supported
+    authorization_signed_response_alg: *sig_alg_supported
+
+    #Various informations of the client
+    client_id: # this field is autopopulated using internal variables base_url and name using the following format: "<base_url>/<name>" 
+    client_name: Name of an example organization
+    contacts:
+      - ops@verifier.example.org
+    default_acr_values:
+      - https://www.spid.gov.it/SpidL2
+      - https://www.spid.gov.it/SpidL3
+
+    #The following section contains all the algorithms supported for the encryption of id token response
+    id_token_encrypted_response_alg: *enc_alg_supported
+    id_token_encrypted_response_enc: *enc_enc_supported
+    id_token_signed_response_alg: *sig_alg_supported
+
+    # public part loaded in the __init__
+    jwks: *metadata_jwks
+
+    redirect_uris: 
+      # This field is autopopulated using internal variables base_url and name using the following format: <base_url>/<name>/redirect-uri"
+    request_uris: 
+      # This field is autopopulated using internal variables base_url and name using the following format: <base_url>/<name>/request-uri"
+
+    # not necessary according to openid4vp
+    # default_max_age: 1111
+    # require_auth_time: true
+    # subject_type: pairwise
+
+    vp_formats:
+      dc+sd-jwt:
+        sd-jwt_alg_values:
+          - ES256
+          - ES384
+        kb-jwt_alg_values:
+          - ES256
+          - ES384
+
+  credential_presentation_handlers:
+    max_submission_size: 4096
+    formats:
+      - module: pyeudiw.openid4vp.vp_sd_jwt_vc
+        class:  VpVcSdJwtParserVerifier
+        format: dc+sd-jwt
+        config:
+          sig_alg_supported: *sig_alg_supported
+      - module: pyeudiw.openid4vp.vp_mdoc_cbor
+        class:  VpMDocCbor
+        format: mso_mdoc
+
+  trust:
+    direct_trust_sd_jwt_vc:
+      module: pyeudiw.trust.handler.direct_trust_sd_jwt_vc
+      class: DirectTrustSdJwtVc
+      config:
+        cache_ttl: 0
+        httpc_params: *httpc_params
+        jwk_endpoint: /.well-known/jwt-vc-issuer
+    direct_trust_jar:
+      module: pyeudiw.trust.handler.direct_trust_jar
+      class: DirectTrustJar
+      config:
+        cache_ttl: 0
+        httpc_params: *httpc_params
+        jwk_endpoint: /.well-known/jar-issuer
+        jwks: *metadata_jwks
+    federation:
+      module: pyeudiw.trust.handler.federation
+      class: FederationHandler
+      config:
+        httpc_params: *httpc_params
+        cache_ttl: 0
+        entity_configuration_exp: 600
+        metadata_type: "openid_credential_verifier"
+        metadata: *metadata
+        authority_hints:
+            - http://127.0.0.1:8000
+        trust_anchors:
+            - http://127.0.0.1:8000:
+              -
+            - https://trust-anchor.edu:
+              -
+            - https://trust-anchor.example.org:
+              - kty: RSA
+                d: QUZsh1NqvpueootsdSjFQz-BUvxwd3Qnzm5qNb-WeOsvt3rWMEv0Q8CZrla2tndHTJhwioo1U4NuQey7znijhZ177bUwPPxSW1r68dEnL2U74nKwwoYeeMdEXnUfZSPxzs7nY6b7vtyCoA-AjiVYFOlgKNAItspv1HxeyGCLhLYhKvS_YoTdAeLuegETU5D6K1xGQIuw0nS13Icjz79Y8jC10TX4FdZwdX-NmuIEDP5-s95V9DMENtVqJAVE3L-wO-NdDilyjyOmAbntgsCzYVGH9U3W_djh4t3qVFCv3r0S-DA2FD3THvlrFi655L0QHR3gu_Fbj3b9Ybtajpue_Q
+                e: AQAB
+                kid: 9Cquk0X-fNPSdePQIgQcQZtD6J0IjIRrFigW2PPK_-w
+                n: utqtxbs-jnK0cPsV7aRkkZKA9t4S-WSZa3nCZtYIKDpgLnR_qcpeF0diJZvKOqXmj2cXaKFUE-8uHKAHo7BL7T-Rj2x3vGESh7SG1pE0thDGlXj4yNsg0qNvCXtk703L2H3i1UXwx6nq1uFxD2EcOE4a6qDYBI16Zl71TUZktJwmOejoHl16CPWqDLGo9GUSk_MmHOV20m4wXWkB4qbvpWVY8H6b2a0rB1B1YPOs5ZLYarSYZgjDEg6DMtZ4NgiwZ-4N1aaLwyO-GLwt9Vf-NBKwoxeRyD3zWE2FXRFBbhKGksMrCGnFDsNl5JTlPjaM3kYyImE941ggcuc495m-Fw
+                p: 2zmGXIMCEHPphw778YjVTar1eycih6fFSJ4I4bl1iq167GqO0PjlOx6CZ1-OdBTVU7HfrYRiUK_BnGRdPDn-DQghwwkB79ZdHWL14wXnpB5y-boHz_LxvjsEqXtuQYcIkidOGaMG68XNT1nM4F9a8UKFr5hHYT5_UIQSwsxlRQ0
+                q: 2jMFt2iFrdaYabdXuB4QMboVjPvbLA-IVb6_0hSG_-EueGBvgcBxdFGIZaG6kqHqlB7qMsSzdptU0vn6IgmCZnX-Hlt6c5X7JB_q91PZMLTO01pbZ2Bk58GloalCHnw_mjPh0YPviH5jGoWM5RHyl_HDDMI-UeLkzP7ImxGizrM
+        default_sig_alg: "RS256"
+        trust_marks: [] 
+        federation_entity_metadata:
+            organization_name: IAM Proxy Italia OpenID4VP backend
+            homepage_uri: https://developers.italia.it
+            policy_uri: https://developers.italia.it
+            tos_uri: https://developers.italia.it
+            logo_uri: https://developers.italia.it/assets/icons/logo-it.svg
+        federation_jwks: # !ENV PYEUDIW_FEDERATION_JWKS
+          - kty: RSA
+            d: QUZsh1NqvpueootsdSjFQz-BUvxwd3Qnzm5qNb-WeOsvt3rWMEv0Q8CZrla2tndHTJhwioo1U4NuQey7znijhZ177bUwPPxSW1r68dEnL2U74nKwwoYeeMdEXnUfZSPxzs7nY6b7vtyCoA-AjiVYFOlgKNAItspv1HxeyGCLhLYhKvS_YoTdAeLuegETU5D6K1xGQIuw0nS13Icjz79Y8jC10TX4FdZwdX-NmuIEDP5-s95V9DMENtVqJAVE3L-wO-NdDilyjyOmAbntgsCzYVGH9U3W_djh4t3qVFCv3r0S-DA2FD3THvlrFi655L0QHR3gu_Fbj3b9Ybtajpue_Q
+            e: AQAB
+            kid: 9Cquk0X-fNPSdePQIgQcQZtD6J0IjIRrFigW2PPK_-w
+            n: utqtxbs-jnK0cPsV7aRkkZKA9t4S-WSZa3nCZtYIKDpgLnR_qcpeF0diJZvKOqXmj2cXaKFUE-8uHKAHo7BL7T-Rj2x3vGESh7SG1pE0thDGlXj4yNsg0qNvCXtk703L2H3i1UXwx6nq1uFxD2EcOE4a6qDYBI16Zl71TUZktJwmOejoHl16CPWqDLGo9GUSk_MmHOV20m4wXWkB4qbvpWVY8H6b2a0rB1B1YPOs5ZLYarSYZgjDEg6DMtZ4NgiwZ-4N1aaLwyO-GLwt9Vf-NBKwoxeRyD3zWE2FXRFBbhKGksMrCGnFDsNl5JTlPjaM3kYyImE941ggcuc495m-Fw
+            p: 2zmGXIMCEHPphw778YjVTar1eycih6fFSJ4I4bl1iq167GqO0PjlOx6CZ1-OdBTVU7HfrYRiUK_BnGRdPDn-DQghwwkB79ZdHWL14wXnpB5y-boHz_LxvjsEqXtuQYcIkidOGaMG68XNT1nM4F9a8UKFr5hHYT5_UIQSwsxlRQ0
+            q: 2jMFt2iFrdaYabdXuB4QMboVjPvbLA-IVb6_0hSG_-EueGBvgcBxdFGIZaG6kqHqlB7qMsSzdptU0vn6IgmCZnX-Hlt6c5X7JB_q91PZMLTO01pbZ2Bk58GloalCHnw_mjPh0YPviH5jGoWM5RHyl_HDDMI-UeLkzP7ImxGizrM
+    x509:
+      module: pyeudiw.trust.handler.x509
+      class: X509Handler
+      config:
+        # client_id: *client_id
+        client_id_scheme: x509_san_dns # this will be prepended in the client id scheme used in the request. 
+        certificate_authorities:
+          - ca.example.com: |
+                -----BEGIN CERTIFICATE-----
+                MIIDYzCCAkugAwIBAgIUHVMNJD9vqAA4mR+QAJyEQFW4kjQwDQYJKoZIhvcNAQEL
+                BQAwUjEuMCwGA1UEAwwlQ049Y2EuZXhhbXBsZS5jb20sIE89RXhhbXBsZSBDQSwg
+                Qz1JVDETMBEGA1UECgwKRXhhbXBsZSBDQTELMAkGA1UEBhMCSVQwHhcNMjUwNDAz
+                MTU0NzU2WhcNMjYwNDA0MTU0NzU2WjBSMS4wLAYDVQQDDCVDTj1jYS5leGFtcGxl
+                LmNvbSwgTz1FeGFtcGxlIENBLCBDPUlUMRMwEQYDVQQKDApFeGFtcGxlIENBMQsw
+                CQYDVQQGEwJJVDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMf3zvlY
+                zX1DYgv9QjRusMQjSRNdZi72/ydnxO/cAQ1GsgLZ8ewqIL1CnXtIs6i2F8poUOec
+                g957xk1db6sTqEWXRi5h9IfMUFcd5G7gIbJzjXCiLSVz6m9vZlvqR7BDka1VQhuH
+                rW2xEIE6+F2lWxJ+crimea/c5VlMKBCh+gQldFq3lTu6smGUz8xl8rhleBPgTgZz
+                TO4VuVO1dOb/S4lq9twfVYCTznF9vgaNaNh3la7yjzCf+zpSTGQD8TFO8ws1SZRq
+                O0bkabW8/5XsnwFHLT2LMSPkWMgMD8r+7xef93bvbEy7SA4Hw1Iow2xIIcTDYQ7F
+                77HQ3OjkogHmhrMCAwEAAaMxMC8wEgYDVR0TAQH/BAgwBgEB/wIBATAZBgNVHREE
+                EjAQgg5jYS5leGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEApRUUxw5Dn0wd
+                lFPApjn7n/SZyx5I1XnOHOIk8aWD0KFFa1zsnONlmRDgC8EQ5XKw3nMUwvnCQUR8
+                6FmrqP5gINHdqfvWiitC0eQdDhMhIHvdfUMBicgZ0XDVjDZhD6W9A+IWwR3ySLCf
+                lZHA5JwjYhpAjMYFXwSVZklOre34zJL6CRwgIUKjc9uyGPmlnVRFTUcUqLB9Uq/U
+                dFc7XMPBAbMt1frOJRj6P1OFtubuC0INpEhzivg3+w8bXmpEN6e2hBvIjoNkgnWF
+                O6HVbDnJXTA34/I4snisJfZQ+Z9gln921+2Q27sMvyS7aBqtocDuWB0w3XZ3aCYk
+                DTEzMjUtQA==
+                -----END CERTIFICATE-----
+        relying_party_certificate_chains_by_ca: # X.509 chains in PEM format. Please note: Leaf's certificate MUST be related to metadata_jwks[0]
+            ca.example.com:
+              - |
+                -----BEGIN CERTIFICATE-----
+                MIIDfzCCAmegAwIBAgIUN3niXMK8XOjhIvf6EUD4sz80XIkwDQYJKoZIhvcNAQEL
+                BQAwTjEpMCcGA1UEAwwgaHR0cHM6Ly9pbnRlcm1lZGlhdGUuZXhhbXBsZS5uZXQx
+                FDASBgNVBAoMC0V4YW1wbGUgSU5UMQswCQYDVQQGEwJJVDAeFw0yNTA0MDMxNTQ3
+                NTZaFw0yNjA0MDQxNTQ3NTZaMFcxMTAvBgNVBAMMKENOPWVhZi5leGFtcGxlLmNv
+                bSwgTz1FeGFtcGxlIExlYWYsIEM9SVQxFTATBgNVBAoMDEV4YW1wbGUgTGVhZjEL
+                MAkGA1UEBhMCSVQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCw/qO3
+                VfAkTQkMrHLgHuvcl1vxbptJGhW6fKNYyCXkhp+oXAewmViAIBY95OsAv6LKN2dY
+                LVywe5OpaN2d0Mv6ioRquuqgMDJxWR8VNRMPzX/BWFZTMDDGFAeJPs9NQixXub1U
+                aV8L+R0KlCXkJwrXLHadDUpupY5XX/lacyCc38Sk2bO2RkOcmYp51V245vZ0pbCc
+                tLd9wa9TFdzzsOMDMLa9+BBKhB9cBlvAi3JLo6KcWJScHFG+31ljYhqmMjX7DAMo
+                p5Guo8L59XahZOsyqhgC8gOd/0CMocBsjDurfTX7v55pQwXWFW0DPVd5e8ynTArz
+                +5Kj1WC/W8eEGk7BAgMBAAGjTDBKMAwGA1UdEwEB/wQCMAAwOgYDVR0RBDMwMYIQ
+                bGVhZi5leGFtcGxlLm9yZ4YdaHR0cHM6Ly9leGFtcGxlLmNvbS9PcGVuSUQ0VlAw
+                DQYJKoZIhvcNAQELBQADggEBACF2aoCODW4tziNQs41C9N363xYPt21uIQy0CQ24
+                1hRZ8Ev6yIQ/WORfzciLHZsWizZdS3D5oDY7K+WAgMpDSR0Ah9dXMfJjOxcUib57
+                Zh+YOi443fjU/5/DBHyHgfEvDy1QXXHJuDbgchzAv9u8uY0ibUb/GHy4OKaj9bOI
+                8g6qgZtT2wkfdHQPX+fpwZueTaHhoXJV+JTuE227fIjLZ5ThbvO0xbE3q4I/v+Gu
+                ZZ713LQaG2RwdJWTimJUi6Sro5s0YR6qRGejHmiS1FbJOOG4AAE4PkhkxVogItVE
+                Z4nqCEfD1RT6iwiWyXIYh3cNpWvcE3t4j7e/Su5IhW/Cv2E=
+                -----END CERTIFICATE-----
+              - |
+                -----BEGIN CERTIFICATE-----
+                MIIDRDCCAiygAwIBAgIUUOBXQmkRjQvfhU1YJbMEOMnPxvQwDQYJKoZIhvcNAQEL
+                BQAwUjEuMCwGA1UEAwwlQ049Y2EuZXhhbXBsZS5jb20sIE89RXhhbXBsZSBDQSwg
+                Qz1JVDETMBEGA1UECgwKRXhhbXBsZSBDQTELMAkGA1UEBhMCSVQwHhcNMjUwNDAz
+                MTU0NzU2WhcNMjYwNDA0MTU0NzU2WjBOMSkwJwYDVQQDDCBodHRwczovL2ludGVy
+                bWVkaWF0ZS5leGFtcGxlLm5ldDEUMBIGA1UECgwLRXhhbXBsZSBJTlQxCzAJBgNV
+                BAYTAklUMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsSUAY+mCs1eB
+                /hWKtF0kncwTRn3jgczjZWmUSSBZT3PzqmD9uqlgEBrv2sOGwO4bBDnutCAHhfnl
+                2gXifvg2PJHQWu/g1kVY396K+d91nrqQhUabo2cpEca66t7InPMnXkMR5DG6rNP6
+                l05OLKQIvoTaHzef0rAS4f+5gF7IcRtGq9G8QRnd2lwLmDYRPKY3jp/uvLosOatv
+                Nx5p2XtxETgOSv4GEtjax3jxkMDIIPrHwTJGWwsGvasEI5lQ/G67OjFZjjSaoJ95
+                SSPhXoIydmOmXKDN3GY7ZqT9HntuSzyB3GZ4DMLyOdZdvYvt08hUCJnnY0kGhhtW
+                gW0xb/wyKwIDAQABoxYwFDASBgNVHRMBAf8ECDAGAQH/AgEAMA0GCSqGSIb3DQEB
+                CwUAA4IBAQBAwwumBWSI/guarZsNd8hEOVZ7dWRQDLxfDZB1jKtgqA2jCEbNGwpY
+                41NRRfkTi9EfZXXVdbk9xrjNWVsGdDn/Kh/1/b4uatu2ocRG5R3e2KkZMaK1/Ru2
+                LFP6gvi7i8dvEr8IQqlg+CrEb11CjMXZi36jRZhtSUnUfmUR4hqCN/qzALdiKvHS
+                NpEu0D6x6l7YEhwtpX7bvWdnEzCUrAUltMPO9pZUR1LBSPTCMSd+vUhJw/84EJEg
+                D6Lw8OxzYyzSNOrGTqfplqlHrD/WpI6DB6Yq4Rpefz84AWraGVtZbYAlQMyK1EKS
+                C3Lef0OGQC0anzAXDsGr1As8HdEuSngu
+                -----END CERTIFICATE-----
+              - |
+                -----BEGIN CERTIFICATE-----
+                MIIDYzCCAkugAwIBAgIUHVMNJD9vqAA4mR+QAJyEQFW4kjQwDQYJKoZIhvcNAQEL
+                BQAwUjEuMCwGA1UEAwwlQ049Y2EuZXhhbXBsZS5jb20sIE89RXhhbXBsZSBDQSwg
+                Qz1JVDETMBEGA1UECgwKRXhhbXBsZSBDQTELMAkGA1UEBhMCSVQwHhcNMjUwNDAz
+                MTU0NzU2WhcNMjYwNDA0MTU0NzU2WjBSMS4wLAYDVQQDDCVDTj1jYS5leGFtcGxl
+                LmNvbSwgTz1FeGFtcGxlIENBLCBDPUlUMRMwEQYDVQQKDApFeGFtcGxlIENBMQsw
+                CQYDVQQGEwJJVDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMf3zvlY
+                zX1DYgv9QjRusMQjSRNdZi72/ydnxO/cAQ1GsgLZ8ewqIL1CnXtIs6i2F8poUOec
+                g957xk1db6sTqEWXRi5h9IfMUFcd5G7gIbJzjXCiLSVz6m9vZlvqR7BDka1VQhuH
+                rW2xEIE6+F2lWxJ+crimea/c5VlMKBCh+gQldFq3lTu6smGUz8xl8rhleBPgTgZz
+                TO4VuVO1dOb/S4lq9twfVYCTznF9vgaNaNh3la7yjzCf+zpSTGQD8TFO8ws1SZRq
+                O0bkabW8/5XsnwFHLT2LMSPkWMgMD8r+7xef93bvbEy7SA4Hw1Iow2xIIcTDYQ7F
+                77HQ3OjkogHmhrMCAwEAAaMxMC8wEgYDVR0TAQH/BAgwBgEB/wIBATAZBgNVHREE
+                EjAQgg5jYS5leGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEApRUUxw5Dn0wd
+                lFPApjn7n/SZyx5I1XnOHOIk8aWD0KFFa1zsnONlmRDgC8EQ5XKw3nMUwvnCQUR8
+                6FmrqP5gINHdqfvWiitC0eQdDhMhIHvdfUMBicgZ0XDVjDZhD6W9A+IWwR3ySLCf
+                lZHA5JwjYhpAjMYFXwSVZklOre34zJL6CRwgIUKjc9uyGPmlnVRFTUcUqLB9Uq/U
+                dFc7XMPBAbMt1frOJRj6P1OFtubuC0INpEhzivg3+w8bXmpEN6e2hBvIjoNkgnWF
+                O6HVbDnJXTA34/I4snisJfZQ+Z9gln921+2Q27sMvyS7aBqtocDuWB0w3XZ3aCYk
+                DTEzMjUtQA==
+                -----END CERTIFICATE-----
+
+        private_keys: *metadata_jwks
+
+  # Mongodb database configuration
+  storage:
+    mongo_db:
+      cache:
+        module: pyeudiw.storage.mongo_cache
+        class: MongoCache
+        init_params:
+          url: mongodb://localhost:27017
+          conf:
+            db_name: eudiw
+          # connection_params:
+      storage:
+        module: pyeudiw.storage.mongo_storage
+        class: MongoStorage
+        init_params:
+          url: mongodb://localhost:27017
+          conf:
+            db_name: eudiw
+            db_sessions_collection: sessions
+            db_trust_attestations_collection: trust_attestations
+            db_trust_anchors_collection: trust_anchors
+            db_trust_sources_collection: trust_sources
+            data_ttl: 63072000 # 2 years
+          # - connection_params:

--- a/example/satosa/integration_test/testconfig/potential/wp2uc1/userdenies/pyeudiw_backend.yaml
+++ b/example/satosa/integration_test/testconfig/potential/wp2uc1/userdenies/pyeudiw_backend.yaml
@@ -102,10 +102,10 @@ config:
 
   user_attributes:
     unique_identifiers:
-    - tax_id_code
-    - unique_id
+      - tax_id_code
+      - unique_id
     subject_id_random_value: CHANGEME!
-  
+
   network:
     httpc_params: &httpc_params
       connection:
@@ -115,13 +115,14 @@ config:
 
   # private jwk
   metadata_jwks: &metadata_jwks
-    - crv: P-256 # Please note: this is the first key [0] and it is used for signing the presentation requests
-      d: KzQBowMMoPmSZe7G8QsdEWc1IvR2nsgE8qTOYmMcLtc
-      kid: dDwPWXz5sCtczj7CJbqgPGJ2qQ83gZ9Sfs-tJyULi6s
+    - kty: EC # Please note: this is the first key [0] and it is used for signing the presentation requests
+      d: i0HQiqDPXf-MqC776ztbgOCI9-eARhcUczqJ-7_httc
       use: sig
-      kty: EC
-      x: TSO-KOqdnUj5SUuasdlRB2VVFSqtJOxuR5GftUTuBdk
-      y: ByWgQt1wGBSnF56jQqLdoO1xKUynMY-BHIDB3eXlR7
+      crv: P-256
+      kid: SQgNjv4yU8sfuafJ2DPWq2tnOlK1JSibd3V5KqYRhOk
+      x: Q46FDkhMjewZIP9qP8ZKZIP-ZEemctvjxeP0l3vWHMI
+      y: IT7lsGxdJewmonk9l1_TAVYx_nixydTtI1Sbn0LkfEA
+      alg: ES256
     - kty: RSA
       d: QUZsh1NqvpueootsdSjFQz-BUvxwd3Qnzm5qNb-WeOsvt3rWMEv0Q8CZrla2tndHTJhwioo1U4NuQey7znijhZ177bUwPPxSW1r68dEnL2U74nKwwoYeeMdEXnUfZSPxzs7nY6b7vtyCoA-AjiVYFOlgKNAItspv1HxeyGCLhLYhKvS_YoTdAeLuegETU5D6K1xGQIuw0nS13Icjz79Y8jC10TX4FdZwdX-NmuIEDP5-s95V9DMENtVqJAVE3L-wO-NdDilyjyOmAbntgsCzYVGH9U3W_djh4t3qVFCv3r0S-DA2FD3THvlrFi655L0QHR3gu_Fbj3b9Ybtajpue_Q
       e: AQAB
@@ -194,8 +195,6 @@ config:
       - module: pyeudiw.openid4vp.vp_sd_jwt_vc
         class:  VpVcSdJwtParserVerifier
         format: dc+sd-jwt
-        config:
-          sig_alg_supported: *sig_alg_supported
       - module: pyeudiw.openid4vp.vp_mdoc_cbor
         class:  VpMDocCbor
         format: mso_mdoc
@@ -261,97 +260,98 @@ config:
       class: X509Handler
       config:
         # client_id: *client_id
-        client_id_scheme: x509_san_dns # this will be prepended in the client id scheme used in the request. 
+        client_id_scheme: x509_san_dns # this will be prepended in the client id scheme used in the request.
+        include_issued_jwt_header_param: true # default false; if true, it will include x5c header parameters in the signed presentation request issued by this trust handler
         certificate_authorities:
-          - ca.example.com: |
-                -----BEGIN CERTIFICATE-----
-                MIIDYzCCAkugAwIBAgIUHVMNJD9vqAA4mR+QAJyEQFW4kjQwDQYJKoZIhvcNAQEL
-                BQAwUjEuMCwGA1UEAwwlQ049Y2EuZXhhbXBsZS5jb20sIE89RXhhbXBsZSBDQSwg
-                Qz1JVDETMBEGA1UECgwKRXhhbXBsZSBDQTELMAkGA1UEBhMCSVQwHhcNMjUwNDAz
-                MTU0NzU2WhcNMjYwNDA0MTU0NzU2WjBSMS4wLAYDVQQDDCVDTj1jYS5leGFtcGxl
-                LmNvbSwgTz1FeGFtcGxlIENBLCBDPUlUMRMwEQYDVQQKDApFeGFtcGxlIENBMQsw
-                CQYDVQQGEwJJVDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMf3zvlY
-                zX1DYgv9QjRusMQjSRNdZi72/ydnxO/cAQ1GsgLZ8ewqIL1CnXtIs6i2F8poUOec
-                g957xk1db6sTqEWXRi5h9IfMUFcd5G7gIbJzjXCiLSVz6m9vZlvqR7BDka1VQhuH
-                rW2xEIE6+F2lWxJ+crimea/c5VlMKBCh+gQldFq3lTu6smGUz8xl8rhleBPgTgZz
-                TO4VuVO1dOb/S4lq9twfVYCTznF9vgaNaNh3la7yjzCf+zpSTGQD8TFO8ws1SZRq
-                O0bkabW8/5XsnwFHLT2LMSPkWMgMD8r+7xef93bvbEy7SA4Hw1Iow2xIIcTDYQ7F
-                77HQ3OjkogHmhrMCAwEAAaMxMC8wEgYDVR0TAQH/BAgwBgEB/wIBATAZBgNVHREE
-                EjAQgg5jYS5leGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEApRUUxw5Dn0wd
-                lFPApjn7n/SZyx5I1XnOHOIk8aWD0KFFa1zsnONlmRDgC8EQ5XKw3nMUwvnCQUR8
-                6FmrqP5gINHdqfvWiitC0eQdDhMhIHvdfUMBicgZ0XDVjDZhD6W9A+IWwR3ySLCf
-                lZHA5JwjYhpAjMYFXwSVZklOre34zJL6CRwgIUKjc9uyGPmlnVRFTUcUqLB9Uq/U
-                dFc7XMPBAbMt1frOJRj6P1OFtubuC0INpEhzivg3+w8bXmpEN6e2hBvIjoNkgnWF
-                O6HVbDnJXTA34/I4snisJfZQ+Z9gln921+2Q27sMvyS7aBqtocDuWB0w3XZ3aCYk
-                DTEzMjUtQA==
-                -----END CERTIFICATE-----
+          ca.example.com: |
+            -----BEGIN CERTIFICATE-----
+            MIIDYzCCAkugAwIBAgIUHVMNJD9vqAA4mR+QAJyEQFW4kjQwDQYJKoZIhvcNAQEL
+            BQAwUjEuMCwGA1UEAwwlQ049Y2EuZXhhbXBsZS5jb20sIE89RXhhbXBsZSBDQSwg
+            Qz1JVDETMBEGA1UECgwKRXhhbXBsZSBDQTELMAkGA1UEBhMCSVQwHhcNMjUwNDAz
+            MTU0NzU2WhcNMjYwNDA0MTU0NzU2WjBSMS4wLAYDVQQDDCVDTj1jYS5leGFtcGxl
+            LmNvbSwgTz1FeGFtcGxlIENBLCBDPUlUMRMwEQYDVQQKDApFeGFtcGxlIENBMQsw
+            CQYDVQQGEwJJVDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMf3zvlY
+            zX1DYgv9QjRusMQjSRNdZi72/ydnxO/cAQ1GsgLZ8ewqIL1CnXtIs6i2F8poUOec
+            g957xk1db6sTqEWXRi5h9IfMUFcd5G7gIbJzjXCiLSVz6m9vZlvqR7BDka1VQhuH
+            rW2xEIE6+F2lWxJ+crimea/c5VlMKBCh+gQldFq3lTu6smGUz8xl8rhleBPgTgZz
+            TO4VuVO1dOb/S4lq9twfVYCTznF9vgaNaNh3la7yjzCf+zpSTGQD8TFO8ws1SZRq
+            O0bkabW8/5XsnwFHLT2LMSPkWMgMD8r+7xef93bvbEy7SA4Hw1Iow2xIIcTDYQ7F
+            77HQ3OjkogHmhrMCAwEAAaMxMC8wEgYDVR0TAQH/BAgwBgEB/wIBATAZBgNVHREE
+            EjAQgg5jYS5leGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEApRUUxw5Dn0wd
+            lFPApjn7n/SZyx5I1XnOHOIk8aWD0KFFa1zsnONlmRDgC8EQ5XKw3nMUwvnCQUR8
+            6FmrqP5gINHdqfvWiitC0eQdDhMhIHvdfUMBicgZ0XDVjDZhD6W9A+IWwR3ySLCf
+            lZHA5JwjYhpAjMYFXwSVZklOre34zJL6CRwgIUKjc9uyGPmlnVRFTUcUqLB9Uq/U
+            dFc7XMPBAbMt1frOJRj6P1OFtubuC0INpEhzivg3+w8bXmpEN6e2hBvIjoNkgnWF
+            O6HVbDnJXTA34/I4snisJfZQ+Z9gln921+2Q27sMvyS7aBqtocDuWB0w3XZ3aCYk
+            DTEzMjUtQA==
+            -----END CERTIFICATE-----
         relying_party_certificate_chains_by_ca: # X.509 chains in PEM format. Please note: Leaf's certificate MUST be related to metadata_jwks[0]
-            ca.example.com:
-              - |
-                -----BEGIN CERTIFICATE-----
-                MIIDfzCCAmegAwIBAgIUN3niXMK8XOjhIvf6EUD4sz80XIkwDQYJKoZIhvcNAQEL
-                BQAwTjEpMCcGA1UEAwwgaHR0cHM6Ly9pbnRlcm1lZGlhdGUuZXhhbXBsZS5uZXQx
-                FDASBgNVBAoMC0V4YW1wbGUgSU5UMQswCQYDVQQGEwJJVDAeFw0yNTA0MDMxNTQ3
-                NTZaFw0yNjA0MDQxNTQ3NTZaMFcxMTAvBgNVBAMMKENOPWVhZi5leGFtcGxlLmNv
-                bSwgTz1FeGFtcGxlIExlYWYsIEM9SVQxFTATBgNVBAoMDEV4YW1wbGUgTGVhZjEL
-                MAkGA1UEBhMCSVQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCw/qO3
-                VfAkTQkMrHLgHuvcl1vxbptJGhW6fKNYyCXkhp+oXAewmViAIBY95OsAv6LKN2dY
-                LVywe5OpaN2d0Mv6ioRquuqgMDJxWR8VNRMPzX/BWFZTMDDGFAeJPs9NQixXub1U
-                aV8L+R0KlCXkJwrXLHadDUpupY5XX/lacyCc38Sk2bO2RkOcmYp51V245vZ0pbCc
-                tLd9wa9TFdzzsOMDMLa9+BBKhB9cBlvAi3JLo6KcWJScHFG+31ljYhqmMjX7DAMo
-                p5Guo8L59XahZOsyqhgC8gOd/0CMocBsjDurfTX7v55pQwXWFW0DPVd5e8ynTArz
-                +5Kj1WC/W8eEGk7BAgMBAAGjTDBKMAwGA1UdEwEB/wQCMAAwOgYDVR0RBDMwMYIQ
-                bGVhZi5leGFtcGxlLm9yZ4YdaHR0cHM6Ly9leGFtcGxlLmNvbS9PcGVuSUQ0VlAw
-                DQYJKoZIhvcNAQELBQADggEBACF2aoCODW4tziNQs41C9N363xYPt21uIQy0CQ24
-                1hRZ8Ev6yIQ/WORfzciLHZsWizZdS3D5oDY7K+WAgMpDSR0Ah9dXMfJjOxcUib57
-                Zh+YOi443fjU/5/DBHyHgfEvDy1QXXHJuDbgchzAv9u8uY0ibUb/GHy4OKaj9bOI
-                8g6qgZtT2wkfdHQPX+fpwZueTaHhoXJV+JTuE227fIjLZ5ThbvO0xbE3q4I/v+Gu
-                ZZ713LQaG2RwdJWTimJUi6Sro5s0YR6qRGejHmiS1FbJOOG4AAE4PkhkxVogItVE
-                Z4nqCEfD1RT6iwiWyXIYh3cNpWvcE3t4j7e/Su5IhW/Cv2E=
-                -----END CERTIFICATE-----
-              - |
-                -----BEGIN CERTIFICATE-----
-                MIIDRDCCAiygAwIBAgIUUOBXQmkRjQvfhU1YJbMEOMnPxvQwDQYJKoZIhvcNAQEL
-                BQAwUjEuMCwGA1UEAwwlQ049Y2EuZXhhbXBsZS5jb20sIE89RXhhbXBsZSBDQSwg
-                Qz1JVDETMBEGA1UECgwKRXhhbXBsZSBDQTELMAkGA1UEBhMCSVQwHhcNMjUwNDAz
-                MTU0NzU2WhcNMjYwNDA0MTU0NzU2WjBOMSkwJwYDVQQDDCBodHRwczovL2ludGVy
-                bWVkaWF0ZS5leGFtcGxlLm5ldDEUMBIGA1UECgwLRXhhbXBsZSBJTlQxCzAJBgNV
-                BAYTAklUMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsSUAY+mCs1eB
-                /hWKtF0kncwTRn3jgczjZWmUSSBZT3PzqmD9uqlgEBrv2sOGwO4bBDnutCAHhfnl
-                2gXifvg2PJHQWu/g1kVY396K+d91nrqQhUabo2cpEca66t7InPMnXkMR5DG6rNP6
-                l05OLKQIvoTaHzef0rAS4f+5gF7IcRtGq9G8QRnd2lwLmDYRPKY3jp/uvLosOatv
-                Nx5p2XtxETgOSv4GEtjax3jxkMDIIPrHwTJGWwsGvasEI5lQ/G67OjFZjjSaoJ95
-                SSPhXoIydmOmXKDN3GY7ZqT9HntuSzyB3GZ4DMLyOdZdvYvt08hUCJnnY0kGhhtW
-                gW0xb/wyKwIDAQABoxYwFDASBgNVHRMBAf8ECDAGAQH/AgEAMA0GCSqGSIb3DQEB
-                CwUAA4IBAQBAwwumBWSI/guarZsNd8hEOVZ7dWRQDLxfDZB1jKtgqA2jCEbNGwpY
-                41NRRfkTi9EfZXXVdbk9xrjNWVsGdDn/Kh/1/b4uatu2ocRG5R3e2KkZMaK1/Ru2
-                LFP6gvi7i8dvEr8IQqlg+CrEb11CjMXZi36jRZhtSUnUfmUR4hqCN/qzALdiKvHS
-                NpEu0D6x6l7YEhwtpX7bvWdnEzCUrAUltMPO9pZUR1LBSPTCMSd+vUhJw/84EJEg
-                D6Lw8OxzYyzSNOrGTqfplqlHrD/WpI6DB6Yq4Rpefz84AWraGVtZbYAlQMyK1EKS
-                C3Lef0OGQC0anzAXDsGr1As8HdEuSngu
-                -----END CERTIFICATE-----
-              - |
-                -----BEGIN CERTIFICATE-----
-                MIIDYzCCAkugAwIBAgIUHVMNJD9vqAA4mR+QAJyEQFW4kjQwDQYJKoZIhvcNAQEL
-                BQAwUjEuMCwGA1UEAwwlQ049Y2EuZXhhbXBsZS5jb20sIE89RXhhbXBsZSBDQSwg
-                Qz1JVDETMBEGA1UECgwKRXhhbXBsZSBDQTELMAkGA1UEBhMCSVQwHhcNMjUwNDAz
-                MTU0NzU2WhcNMjYwNDA0MTU0NzU2WjBSMS4wLAYDVQQDDCVDTj1jYS5leGFtcGxl
-                LmNvbSwgTz1FeGFtcGxlIENBLCBDPUlUMRMwEQYDVQQKDApFeGFtcGxlIENBMQsw
-                CQYDVQQGEwJJVDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMf3zvlY
-                zX1DYgv9QjRusMQjSRNdZi72/ydnxO/cAQ1GsgLZ8ewqIL1CnXtIs6i2F8poUOec
-                g957xk1db6sTqEWXRi5h9IfMUFcd5G7gIbJzjXCiLSVz6m9vZlvqR7BDka1VQhuH
-                rW2xEIE6+F2lWxJ+crimea/c5VlMKBCh+gQldFq3lTu6smGUz8xl8rhleBPgTgZz
-                TO4VuVO1dOb/S4lq9twfVYCTznF9vgaNaNh3la7yjzCf+zpSTGQD8TFO8ws1SZRq
-                O0bkabW8/5XsnwFHLT2LMSPkWMgMD8r+7xef93bvbEy7SA4Hw1Iow2xIIcTDYQ7F
-                77HQ3OjkogHmhrMCAwEAAaMxMC8wEgYDVR0TAQH/BAgwBgEB/wIBATAZBgNVHREE
-                EjAQgg5jYS5leGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEApRUUxw5Dn0wd
-                lFPApjn7n/SZyx5I1XnOHOIk8aWD0KFFa1zsnONlmRDgC8EQ5XKw3nMUwvnCQUR8
-                6FmrqP5gINHdqfvWiitC0eQdDhMhIHvdfUMBicgZ0XDVjDZhD6W9A+IWwR3ySLCf
-                lZHA5JwjYhpAjMYFXwSVZklOre34zJL6CRwgIUKjc9uyGPmlnVRFTUcUqLB9Uq/U
-                dFc7XMPBAbMt1frOJRj6P1OFtubuC0INpEhzivg3+w8bXmpEN6e2hBvIjoNkgnWF
-                O6HVbDnJXTA34/I4snisJfZQ+Z9gln921+2Q27sMvyS7aBqtocDuWB0w3XZ3aCYk
-                DTEzMjUtQA==
-                -----END CERTIFICATE-----
+          ca.example.com:
+            - |
+              -----BEGIN CERTIFICATE-----
+              MIIDfzCCAmegAwIBAgIUN3niXMK8XOjhIvf6EUD4sz80XIkwDQYJKoZIhvcNAQEL
+              BQAwTjEpMCcGA1UEAwwgaHR0cHM6Ly9pbnRlcm1lZGlhdGUuZXhhbXBsZS5uZXQx
+              FDASBgNVBAoMC0V4YW1wbGUgSU5UMQswCQYDVQQGEwJJVDAeFw0yNTA0MDMxNTQ3
+              NTZaFw0yNjA0MDQxNTQ3NTZaMFcxMTAvBgNVBAMMKENOPWVhZi5leGFtcGxlLmNv
+              bSwgTz1FeGFtcGxlIExlYWYsIEM9SVQxFTATBgNVBAoMDEV4YW1wbGUgTGVhZjEL
+              MAkGA1UEBhMCSVQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCw/qO3
+              VfAkTQkMrHLgHuvcl1vxbptJGhW6fKNYyCXkhp+oXAewmViAIBY95OsAv6LKN2dY
+              LVywe5OpaN2d0Mv6ioRquuqgMDJxWR8VNRMPzX/BWFZTMDDGFAeJPs9NQixXub1U
+              aV8L+R0KlCXkJwrXLHadDUpupY5XX/lacyCc38Sk2bO2RkOcmYp51V245vZ0pbCc
+              tLd9wa9TFdzzsOMDMLa9+BBKhB9cBlvAi3JLo6KcWJScHFG+31ljYhqmMjX7DAMo
+              p5Guo8L59XahZOsyqhgC8gOd/0CMocBsjDurfTX7v55pQwXWFW0DPVd5e8ynTArz
+              +5Kj1WC/W8eEGk7BAgMBAAGjTDBKMAwGA1UdEwEB/wQCMAAwOgYDVR0RBDMwMYIQ
+              bGVhZi5leGFtcGxlLm9yZ4YdaHR0cHM6Ly9leGFtcGxlLmNvbS9PcGVuSUQ0VlAw
+              DQYJKoZIhvcNAQELBQADggEBACF2aoCODW4tziNQs41C9N363xYPt21uIQy0CQ24
+              1hRZ8Ev6yIQ/WORfzciLHZsWizZdS3D5oDY7K+WAgMpDSR0Ah9dXMfJjOxcUib57
+              Zh+YOi443fjU/5/DBHyHgfEvDy1QXXHJuDbgchzAv9u8uY0ibUb/GHy4OKaj9bOI
+              8g6qgZtT2wkfdHQPX+fpwZueTaHhoXJV+JTuE227fIjLZ5ThbvO0xbE3q4I/v+Gu
+              ZZ713LQaG2RwdJWTimJUi6Sro5s0YR6qRGejHmiS1FbJOOG4AAE4PkhkxVogItVE
+              Z4nqCEfD1RT6iwiWyXIYh3cNpWvcE3t4j7e/Su5IhW/Cv2E=
+              -----END CERTIFICATE-----
+            - |
+              -----BEGIN CERTIFICATE-----
+              MIIDRDCCAiygAwIBAgIUUOBXQmkRjQvfhU1YJbMEOMnPxvQwDQYJKoZIhvcNAQEL
+              BQAwUjEuMCwGA1UEAwwlQ049Y2EuZXhhbXBsZS5jb20sIE89RXhhbXBsZSBDQSwg
+              Qz1JVDETMBEGA1UECgwKRXhhbXBsZSBDQTELMAkGA1UEBhMCSVQwHhcNMjUwNDAz
+              MTU0NzU2WhcNMjYwNDA0MTU0NzU2WjBOMSkwJwYDVQQDDCBodHRwczovL2ludGVy
+              bWVkaWF0ZS5leGFtcGxlLm5ldDEUMBIGA1UECgwLRXhhbXBsZSBJTlQxCzAJBgNV
+              BAYTAklUMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsSUAY+mCs1eB
+              /hWKtF0kncwTRn3jgczjZWmUSSBZT3PzqmD9uqlgEBrv2sOGwO4bBDnutCAHhfnl
+              2gXifvg2PJHQWu/g1kVY396K+d91nrqQhUabo2cpEca66t7InPMnXkMR5DG6rNP6
+              l05OLKQIvoTaHzef0rAS4f+5gF7IcRtGq9G8QRnd2lwLmDYRPKY3jp/uvLosOatv
+              Nx5p2XtxETgOSv4GEtjax3jxkMDIIPrHwTJGWwsGvasEI5lQ/G67OjFZjjSaoJ95
+              SSPhXoIydmOmXKDN3GY7ZqT9HntuSzyB3GZ4DMLyOdZdvYvt08hUCJnnY0kGhhtW
+              gW0xb/wyKwIDAQABoxYwFDASBgNVHRMBAf8ECDAGAQH/AgEAMA0GCSqGSIb3DQEB
+              CwUAA4IBAQBAwwumBWSI/guarZsNd8hEOVZ7dWRQDLxfDZB1jKtgqA2jCEbNGwpY
+              41NRRfkTi9EfZXXVdbk9xrjNWVsGdDn/Kh/1/b4uatu2ocRG5R3e2KkZMaK1/Ru2
+              LFP6gvi7i8dvEr8IQqlg+CrEb11CjMXZi36jRZhtSUnUfmUR4hqCN/qzALdiKvHS
+              NpEu0D6x6l7YEhwtpX7bvWdnEzCUrAUltMPO9pZUR1LBSPTCMSd+vUhJw/84EJEg
+              D6Lw8OxzYyzSNOrGTqfplqlHrD/WpI6DB6Yq4Rpefz84AWraGVtZbYAlQMyK1EKS
+              C3Lef0OGQC0anzAXDsGr1As8HdEuSngu
+              -----END CERTIFICATE-----
+            - |
+              -----BEGIN CERTIFICATE-----
+              MIIDYzCCAkugAwIBAgIUHVMNJD9vqAA4mR+QAJyEQFW4kjQwDQYJKoZIhvcNAQEL
+              BQAwUjEuMCwGA1UEAwwlQ049Y2EuZXhhbXBsZS5jb20sIE89RXhhbXBsZSBDQSwg
+              Qz1JVDETMBEGA1UECgwKRXhhbXBsZSBDQTELMAkGA1UEBhMCSVQwHhcNMjUwNDAz
+              MTU0NzU2WhcNMjYwNDA0MTU0NzU2WjBSMS4wLAYDVQQDDCVDTj1jYS5leGFtcGxl
+              LmNvbSwgTz1FeGFtcGxlIENBLCBDPUlUMRMwEQYDVQQKDApFeGFtcGxlIENBMQsw
+              CQYDVQQGEwJJVDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMf3zvlY
+              zX1DYgv9QjRusMQjSRNdZi72/ydnxO/cAQ1GsgLZ8ewqIL1CnXtIs6i2F8poUOec
+              g957xk1db6sTqEWXRi5h9IfMUFcd5G7gIbJzjXCiLSVz6m9vZlvqR7BDka1VQhuH
+              rW2xEIE6+F2lWxJ+crimea/c5VlMKBCh+gQldFq3lTu6smGUz8xl8rhleBPgTgZz
+              TO4VuVO1dOb/S4lq9twfVYCTznF9vgaNaNh3la7yjzCf+zpSTGQD8TFO8ws1SZRq
+              O0bkabW8/5XsnwFHLT2LMSPkWMgMD8r+7xef93bvbEy7SA4Hw1Iow2xIIcTDYQ7F
+              77HQ3OjkogHmhrMCAwEAAaMxMC8wEgYDVR0TAQH/BAgwBgEB/wIBATAZBgNVHREE
+              EjAQgg5jYS5leGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEApRUUxw5Dn0wd
+              lFPApjn7n/SZyx5I1XnOHOIk8aWD0KFFa1zsnONlmRDgC8EQ5XKw3nMUwvnCQUR8
+              6FmrqP5gINHdqfvWiitC0eQdDhMhIHvdfUMBicgZ0XDVjDZhD6W9A+IWwR3ySLCf
+              lZHA5JwjYhpAjMYFXwSVZklOre34zJL6CRwgIUKjc9uyGPmlnVRFTUcUqLB9Uq/U
+              dFc7XMPBAbMt1frOJRj6P1OFtubuC0INpEhzivg3+w8bXmpEN6e2hBvIjoNkgnWF
+              O6HVbDnJXTA34/I4snisJfZQ+Z9gln921+2Q27sMvyS7aBqtocDuWB0w3XZ3aCYk
+              DTEzMjUtQA==
+              -----END CERTIFICATE-----
 
         private_keys: *metadata_jwks
 

--- a/example/satosa/integration_test/user_denies_end_to_end_test.py
+++ b/example/satosa/integration_test/user_denies_end_to_end_test.py
@@ -1,0 +1,172 @@
+# This file contains a flow that simulates an end-to-end flow from the user
+# perspective in the case where he denies to share his credentials at the wallet side.
+# From a techical point of view, this flow is the Authorization Error Response flow
+# descirbed in OpenID4VP.
+# Both same device and cross device are tested.
+#
+# This integration test should be run with the configuraiton file located in
+#    testconfig/potential/wp2uc1/userdenies/pyeudiw_backend.yaml
+
+import re
+import time
+import requests
+import urllib.parse
+
+from playwright.sync_api import sync_playwright, Playwright
+from pyeudiw.jwt.utils import decode_jwt_payload
+
+from commons import (
+    apply_trust_settings,
+    create_authorize_error_response_user_denies,
+    create_saml_auth_request,
+    extract_content_title_login_page,
+    extract_request_uri_login_page,
+    get_new_browser_page,
+    setup_test_db_engine,
+    verify_request_object_jwt,
+    verify_status_login_page
+)
+
+from settings import TIMEOUT_S
+
+
+def _same_device_extract_request_uri(e: Exception) -> str:
+    request_uri: str = re.search(r'request_uri=(.*?)(?:\'|\s|$)', urllib.parse.unquote_plus(e.args[0])).group(1)
+    request_uri = request_uri.rstrip()
+    return request_uri
+
+
+def same_device():
+    # initialize the user-agent
+    http_user_agent = requests.Session()
+
+    auth_req_url = create_saml_auth_request()
+    headers_mobile = {
+        "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B137 Safari/601.1"
+    }
+    request_uri = ""
+
+    try:
+        _ = http_user_agent.get(
+            url=auth_req_url,
+            verify=False,
+            headers=headers_mobile,
+            timeout=TIMEOUT_S
+        )
+    except requests.exceptions.InvalidSchema as e:
+        # custom url scheme such as 'haip' or 'eudiw' will raise this exception
+        request_uri = _same_device_extract_request_uri(e)
+    except requests.exceptions.ConnectionError as e:
+        # universal link such as 'https://wallet.example' will raise this exception
+        request_uri = _same_device_extract_request_uri(e.args[0])
+
+    signed_request_obj = http_user_agent.get(
+        request_uri,
+        verify=False,
+        timeout=TIMEOUT_S)
+
+    verify_request_object_jwt(signed_request_obj.text, http_user_agent)
+
+    request_object_claims = decode_jwt_payload(signed_request_obj.text)
+    response_uri = request_object_claims["response_uri"]
+
+    wallet_response_data = create_authorize_error_response_user_denies(
+        request_object_claims["state"]
+    )
+
+    authz_error_response = http_user_agent.post(
+        response_uri,
+        verify=False,
+        data=wallet_response_data,
+        timeout=TIMEOUT_S
+    )
+
+    assert authz_error_response.status_code == 200
+    assert authz_error_response.json().get("redirect_uri", None) is not None
+
+    callback_uri = authz_error_response.json().get("redirect_uri", None)
+    satosa_authn_error_response = http_user_agent.get(
+        callback_uri,
+        verify=False,
+        timeout=TIMEOUT_S
+    )
+
+    assert satosa_authn_error_response.status_code == 401
+    assert "Authentication Failure" in satosa_authn_error_response.text
+
+    http_user_agent.close()
+    print("TEST CASE SAME DEVICE PASSED")
+
+
+def cross_device():
+
+    def _run_cross_device(playwright: Playwright):
+        # initialize the user-agent(s)
+        wallet_user_agent = requests.Session()
+        login_page = get_new_browser_page(playwright)
+
+        # Authentication Flow Step 1: init authentication (pre request endpoint)
+        auth_req_url = create_saml_auth_request()
+        login_page.goto(auth_req_url)
+
+        verify_status_login_page(login_page, 201)
+
+        request_uri = extract_request_uri_login_page(login_page.content())
+
+        # Authentication Flow Step 2: get request object in request endpoint
+        sign_request_obj = wallet_user_agent.get(
+            request_uri,
+            verify=False,
+            timeout=TIMEOUT_S)
+
+        verify_request_object_jwt(sign_request_obj.text, wallet_user_agent)
+
+        request_object_claims = decode_jwt_payload(sign_request_obj.text)
+        response_uri = request_object_claims["response_uri"]
+
+        verify_status_login_page(login_page, expected_code=202)
+
+        # Authentication Flow Step 3: user denies and wallet provides an authentication error response in the response endpoint
+        wallet_response_data = create_authorize_error_response_user_denies(
+            request_object_claims["state"]
+        )
+
+        authz_error_response = wallet_user_agent.post(
+            response_uri,
+            verify=False,
+            data=wallet_response_data,
+            timeout=TIMEOUT_S
+        )
+
+        assert authz_error_response.status_code == 200
+        assert authz_error_response.json().get("redirect_uri", None) is None
+
+        # Authentication Flow Step 4: user calls a link ("Vai al servizio") with the response code to finish login page interaction
+
+        # wait that js polling catches the updated backend status
+        print("\n...waiting that the page updates...\n")
+        time.sleep(1.0)
+        verify_status_login_page(login_page, 401)
+
+        # check that the page content was updated
+        assert "Autenticazione fallita" in extract_content_title_login_page(login_page.content())
+
+        wallet_user_agent.close()
+        login_page.close()
+        print("TEST CASE CROSS DEVICE PASSED")
+
+    with sync_playwright() as playwright:
+        _run_cross_device(playwright)
+
+
+if __name__ == "__main__":
+    # -- SET UP --
+    db_engine_inst = setup_test_db_engine()
+    db_engine_inst = apply_trust_settings(db_engine_inst)
+
+    # -- TEST --
+    same_device()
+    cross_device()
+
+    # -- TEAR DOWN --
+    # (no teardown scrictly required as of now)

--- a/example/satosa/pyeudiw_backend.yaml
+++ b/example/satosa/pyeudiw_backend.yaml
@@ -101,6 +101,9 @@ config:
             - path:
               - "$.given_name"
 
+  duckle:
+    dcql_query: '{"credentials":[{"id":"personal id data","format":"dc+sd-jwt","meta":{"vct_values":["https://trust-registry.eid-wallet.example.it/credentials/v1.0/personidentificationdata"]},"claims":[{"path":["given_name"]},{"path":["family_name"]}]},{"id":"wallet attestation","format":"dc+sd-jwt","meta":{"vct_values":["https://itwallet.registry.example.it/WalletAttestation"]},"claims":[{"path":["wallet_link"]},{"path":["wallet_name"]}]}]}'
+
   user_attributes:
     unique_identifiers:
     - tax_id_code
@@ -199,6 +202,9 @@ config:
       - module: pyeudiw.openid4vp.vp_mdoc_cbor
         class:  VpMDocCbor
         format: mso_mdoc
+      - module: pyeudiw.duckle_ql.handler
+        class: DuckleHandler
+        format: jwt_vc_json
 
   trust:
     direct_trust_sd_jwt_vc:

--- a/example/satosa/pyeudiw_backend.yaml
+++ b/example/satosa/pyeudiw_backend.yaml
@@ -9,6 +9,7 @@ config:
     qrcode_template: "qr_code.html"
     error_template: "error.html"
     error_url: "https://localhost/error_page.html"
+    authorization_error_template: "authorization_error.html"
   
   endpoints:
     pre_request: '/pre-request'

--- a/example/satosa/pyeudiw_backend.yaml
+++ b/example/satosa/pyeudiw_backend.yaml
@@ -101,9 +101,6 @@ config:
             - path:
               - "$.given_name"
 
-  duckle:
-    dcql_query: '{"credentials":[{"id":"personal id data","format":"dc+sd-jwt","meta":{"vct_values":["https://trust-registry.eid-wallet.example.it/credentials/v1.0/personidentificationdata"]},"claims":[{"path":["given_name"]},{"path":["family_name"]}]},{"id":"wallet attestation","format":"dc+sd-jwt","meta":{"vct_values":["https://itwallet.registry.example.it/WalletAttestation"]},"claims":[{"path":["wallet_link"]},{"path":["wallet_name"]}]}]}'
-
   user_attributes:
     unique_identifiers:
     - tax_id_code
@@ -135,6 +132,18 @@ config:
       n: utqtxbs-jnK0cPsV7aRkkZKA9t4S-WSZa3nCZtYIKDpgLnR_qcpeF0diJZvKOqXmj2cXaKFUE-8uHKAHo7BL7T-Rj2x3vGESh7SG1pE0thDGlXj4yNsg0qNvCXtk703L2H3i1UXwx6nq1uFxD2EcOE4a6qDYBI16Zl71TUZktJwmOejoHl16CPWqDLGo9GUSk_MmHOV20m4wXWkB4qbvpWVY8H6b2a0rB1B1YPOs5ZLYarSYZgjDEg6DMtZ4NgiwZ-4N1aaLwyO-GLwt9Vf-NBKwoxeRyD3zWE2FXRFBbhKGksMrCGnFDsNl5JTlPjaM3kYyImE941ggcuc495m-Fw
       p: 2zmGXIMCEHPphw778YjVTar1eycih6fFSJ4I4bl1iq167GqO0PjlOx6CZ1-OdBTVU7HfrYRiUK_BnGRdPDn-DQghwwkB79ZdHWL14wXnpB5y-boHz_LxvjsEqXtuQYcIkidOGaMG68XNT1nM4F9a8UKFr5hHYT5_UIQSwsxlRQ0
       q: 2jMFt2iFrdaYabdXuB4QMboVjPvbLA-IVb6_0hSG_-EueGBvgcBxdFGIZaG6kqHqlB7qMsSzdptU0vn6IgmCZnX-Hlt6c5X7JB_q91PZMLTO01pbZ2Bk58GloalCHnw_mjPh0YPviH5jGoWM5RHyl_HDDMI-UeLkzP7ImxGizrM
+    - kty: RSA
+      use: sig
+      alg: RS256
+      kid: m00NPAelNBnG_wK2R5EpI_k-GWCHEUySamQYubgFjCg
+      d: nMsnqz0lPHNGBgUqyuJ5nXQ0jh-mzs6d2xOY_QhpkRW1kEbexRJDdVV3fqMxj_s0MiF8mn-s8ea3e8cbNDgIy000Wvx05y1rMkB6KaZX2ZL5jwU7i_xP6NlLh8itikqJz7kKQSILgibQFFQDcScpEk8gUKa6fmSJQVwTII6GoJCdiJflv-FI2OQ_TCBQEEVVLpeUiVSP0n3OMUKGBlbaHOQkArUpla_ke_mtdfIrl7uB74Rxrin68KtFHkGDGdJPs-PPO1yJ2paFZI9QR_ettZ22v45c-qIgmCjsEnITDMaO9724PU_umlWsWe36Y9RAAzofKsjKqvA1OIzU03ob9Q
+      n: sP6jt1XwJE0JDKxy4B7r3Jdb8W6bSRoVunyjWMgl5IafqFwHsJlYgCAWPeTrAL-iyjdnWC1csHuTqWjdndDL-oqEarrqoDAycVkfFTUTD81_wVhWUzAwxhQHiT7PTUIsV7m9VGlfC_kdCpQl5CcK1yx2nQ1KbqWOV1_5WnMgnN_EpNmztkZDnJmKedVduOb2dKWwnLS3fcGvUxXc87DjAzC2vfgQSoQfXAZbwItyS6OinFiUnBxRvt9ZY2IapjI1-wwDKKeRrqPC-fV2oWTrMqoYAvIDnf9AjKHAbIw7q301-7-eaUMF1hVtAz1XeXvMp0wK8_uSo9Vgv1vHhBpOwQ
+      e: AQAB
+      p: 0ViKTSyZdLtvbLBpTvVAXTdrhTwGXuh16PadQMAVmkoxOPiExRB5uLiy2ADaVKSglia5aQBUp9v0ygEEOmkiUtn5A26D9ui0dkPR0hx4fwqCOOmA2ZyDUNFJ_qrGSwT1SxGQDHeRteymJG7uN9QekS3XiBDgFJxwl-vVpoSTBJM
+      q: 2HBr9qhVd3zZUQuNb7ro06ErLl4fhL-DiKsNqXB772tDNTJYeog1nOWgS22tcv5WHrSoYF1x5Q74YVoA6yVj6DwFx2Hc2pYZazzhYMRC3NAWkTEdroy9IjtpzKIpQIqw-sq8CbWVBXzho8uQBCdg8h73z11_HPyXT9BqQCmxJ9s
+      dp: WsQ32rQuqNUnv4lRb4GYcZI41SCsZnQFw4dBsTRXaXknlFr0PfkhvXyfVlYwU6i5U8DgfO0-xzTwErGUIrs4vZFyjRFauDA3JlvLWn0rpXFp-sELM87PhLfpjDiBFz_EFtM7kJw7GhTMCFnsgVpAEpQ8sesXLPiTPNts2_D5SW8
+      dq: jWlucLrtFGOjDRuyLjT9l__uWZ4vk6kZRHsWMwWGRBhd0ezx-CT0em1hPMcNE1vvYqKAfG2xU4pjaB_JB9nnG73TvMBI7xwwwWsGihXQ5bqjc_uWPAxCKpKM_qFYuI2lMkaxctqL4gkE1-LRVpVv9uGa4YZh3ct_BSvTr9ZNpA8
+      qi: kn9Etj4a2erCUmoZUQalPjHxCRYm5Q3wAkFIRGSQADA51mkwQHyTYqXbHcmXn2ZgXBVI6XDWJB51Me-NCPfITTlusqxvATF7Q-QJtdK_FbgNtcVRNc1FMq_M7VBHA1i9wJR7T4t57aywfXPmlsA5TToTDRe-ybdw0C3ys4KQATs
 
   #This is the configuration for the relaying party metadata
   metadata: &metadata
@@ -190,9 +199,6 @@ config:
       - module: pyeudiw.openid4vp.vp_mdoc_cbor
         class:  VpMDocCbor
         format: mso_mdoc
-      - module: pyeudiw.duckle_ql.handler
-        class: DuckleHandler
-        format: jwt_vc_json
 
   trust:
     direct_trust_sd_jwt_vc:
@@ -261,59 +267,93 @@ config:
         certificate_authorities:
           ca.example.com: |
             -----BEGIN CERTIFICATE-----
-            MIIB2DCCAX2gAwIBAgIULx2ECoVuwx8Hjz9KT8LU2UnO5fcwCgYIKoZIzj0EAwIw
-            UjEuMCwGA1UEAwwlQ049Y2EuZXhhbXBsZS5jb20sIE89RXhhbXBsZSBDQSwgQz1J
-            VDETMBEGA1UECgwKRXhhbXBsZSBDQTELMAkGA1UEBhMCSVQwHhcNMjUwNDA5MTIw
-            ODUwWhcNMjYwNDEwMTIwODUwWjBSMS4wLAYDVQQDDCVDTj1jYS5leGFtcGxlLmNv
-            bSwgTz1FeGFtcGxlIENBLCBDPUlUMRMwEQYDVQQKDApFeGFtcGxlIENBMQswCQYD
-            VQQGEwJJVDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFnk7w/2CELwYAo1HYjh
-            v07QS3Xo3HL1Qt/SD2s5pcBmENuFzPUS8E1JFZ047hfaGIb+6NQdUcNt7RGBQgvJ
-            cNqjMTAvMBIGA1UdEwEB/wQIMAYBAf8CAQEwGQYDVR0RBBIwEIIOY2EuZXhhbXBs
-            ZS5jb20wCgYIKoZIzj0EAwIDSQAwRgIhAJLASYXdk77YGrVeuj2bdy48fFeGcHwY
-            hEt3dD1GqdqkAiEAqekBRTF9wzJ/lPmRJyPdLoxzGBbIkd53NCtGUfNvaL0=
+            MIIDYzCCAkugAwIBAgIUHVMNJD9vqAA4mR+QAJyEQFW4kjQwDQYJKoZIhvcNAQEL
+            BQAwUjEuMCwGA1UEAwwlQ049Y2EuZXhhbXBsZS5jb20sIE89RXhhbXBsZSBDQSwg
+            Qz1JVDETMBEGA1UECgwKRXhhbXBsZSBDQTELMAkGA1UEBhMCSVQwHhcNMjUwNDAz
+            MTU0NzU2WhcNMjYwNDA0MTU0NzU2WjBSMS4wLAYDVQQDDCVDTj1jYS5leGFtcGxl
+            LmNvbSwgTz1FeGFtcGxlIENBLCBDPUlUMRMwEQYDVQQKDApFeGFtcGxlIENBMQsw
+            CQYDVQQGEwJJVDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMf3zvlY
+            zX1DYgv9QjRusMQjSRNdZi72/ydnxO/cAQ1GsgLZ8ewqIL1CnXtIs6i2F8poUOec
+            g957xk1db6sTqEWXRi5h9IfMUFcd5G7gIbJzjXCiLSVz6m9vZlvqR7BDka1VQhuH
+            rW2xEIE6+F2lWxJ+crimea/c5VlMKBCh+gQldFq3lTu6smGUz8xl8rhleBPgTgZz
+            TO4VuVO1dOb/S4lq9twfVYCTznF9vgaNaNh3la7yjzCf+zpSTGQD8TFO8ws1SZRq
+            O0bkabW8/5XsnwFHLT2LMSPkWMgMD8r+7xef93bvbEy7SA4Hw1Iow2xIIcTDYQ7F
+            77HQ3OjkogHmhrMCAwEAAaMxMC8wEgYDVR0TAQH/BAgwBgEB/wIBATAZBgNVHREE
+            EjAQgg5jYS5leGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEApRUUxw5Dn0wd
+            lFPApjn7n/SZyx5I1XnOHOIk8aWD0KFFa1zsnONlmRDgC8EQ5XKw3nMUwvnCQUR8
+            6FmrqP5gINHdqfvWiitC0eQdDhMhIHvdfUMBicgZ0XDVjDZhD6W9A+IWwR3ySLCf
+            lZHA5JwjYhpAjMYFXwSVZklOre34zJL6CRwgIUKjc9uyGPmlnVRFTUcUqLB9Uq/U
+            dFc7XMPBAbMt1frOJRj6P1OFtubuC0INpEhzivg3+w8bXmpEN6e2hBvIjoNkgnWF
+            O6HVbDnJXTA34/I4snisJfZQ+Z9gln921+2Q27sMvyS7aBqtocDuWB0w3XZ3aCYk
+            DTEzMjUtQA==
             -----END CERTIFICATE-----
         relying_party_certificate_chains_by_ca: # X.509 chains in PEM format. Please note: Leaf's certificate MUST be related to metadata_jwks[0]
-            ca.example.com:
-              - |
-                -----BEGIN CERTIFICATE-----
-                MIIB8zCCAZmgAwIBAgIUDHO8luqRDrcn+Vm+dWjca+iCX2MwCgYIKoZIzj0EAwIw
-                TjEpMCcGA1UEAwwgaHR0cHM6Ly9pbnRlcm1lZGlhdGUuZXhhbXBsZS5uZXQxFDAS
-                BgNVBAoMC0V4YW1wbGUgSU5UMQswCQYDVQQGEwJJVDAeFw0yNTA0MDkxMjA4NTBa
-                Fw0yNjA0MTAxMjA4NTBaMFcxMTAvBgNVBAMMKENOPWVhZi5leGFtcGxlLmNvbSwg
-                Tz1FeGFtcGxlIExlYWYsIEM9SVQxFTATBgNVBAoMDEV4YW1wbGUgTGVhZjELMAkG
-                A1UEBhMCSVQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARDjoUOSEyN7Bkg/2o/
-                xkpkg/5kR6Zy2+PF4/SXe9YcwiE+5bBsXSXsJqJ5PZdf0wFWMf54scnU7SNUm59C
-                5HxAo0wwSjAMBgNVHRMBAf8EAjAAMDoGA1UdEQQzMDGCEGxlYWYuZXhhbXBsZS5v
-                cmeGHWh0dHBzOi8vZXhhbXBsZS5jb20vT3BlbklENFZQMAoGCCqGSM49BAMCA0gA
-                MEUCIFa4Cbi9ZwpbcCYfZ7HivE55+lTTew0rm4nucoVUZUnWAiEA4zdbGSg9hDbp
-                YpYZqBWSu13gPR95PHwAuuHHaV996jc=
-                -----END CERTIFICATE-----
-              - |
-                -----BEGIN CERTIFICATE-----
-                MIIBuDCCAV6gAwIBAgIUXMe7NM/UP3adIoD7VZpSdCx8EOEwCgYIKoZIzj0EAwIw
-                UjEuMCwGA1UEAwwlQ049Y2EuZXhhbXBsZS5jb20sIE89RXhhbXBsZSBDQSwgQz1J
-                VDETMBEGA1UECgwKRXhhbXBsZSBDQTELMAkGA1UEBhMCSVQwHhcNMjUwNDA5MTIw
-                ODUwWhcNMjYwNDEwMTIwODUwWjBOMSkwJwYDVQQDDCBodHRwczovL2ludGVybWVk
-                aWF0ZS5leGFtcGxlLm5ldDEUMBIGA1UECgwLRXhhbXBsZSBJTlQxCzAJBgNVBAYT
-                AklUMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEiB2ez55arVjtvNYEX25Ctb0b
-                SOB3QABzBUTpWFo4utrMsnU9x+mxPDp87IU5KY0fOEjtZY3d6m8WS3Bla6wyQaMW
-                MBQwEgYDVR0TAQH/BAgwBgEB/wIBADAKBggqhkjOPQQDAgNIADBFAiEAxRqSBdrO
-                EKgGqspslHJ411Owkx6AxGUnJbtRhojk1OkCIC+pV6wm/fWtFDk1Sxq1WQp6ZHaZ
-                a7vw4qcqrfQK9EEE
-                -----END CERTIFICATE-----
-              - |
-                -----BEGIN CERTIFICATE-----
-                MIIB2DCCAX2gAwIBAgIULx2ECoVuwx8Hjz9KT8LU2UnO5fcwCgYIKoZIzj0EAwIw
-                UjEuMCwGA1UEAwwlQ049Y2EuZXhhbXBsZS5jb20sIE89RXhhbXBsZSBDQSwgQz1J
-                VDETMBEGA1UECgwKRXhhbXBsZSBDQTELMAkGA1UEBhMCSVQwHhcNMjUwNDA5MTIw
-                ODUwWhcNMjYwNDEwMTIwODUwWjBSMS4wLAYDVQQDDCVDTj1jYS5leGFtcGxlLmNv
-                bSwgTz1FeGFtcGxlIENBLCBDPUlUMRMwEQYDVQQKDApFeGFtcGxlIENBMQswCQYD
-                VQQGEwJJVDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFnk7w/2CELwYAo1HYjh
-                v07QS3Xo3HL1Qt/SD2s5pcBmENuFzPUS8E1JFZ047hfaGIb+6NQdUcNt7RGBQgvJ
-                cNqjMTAvMBIGA1UdEwEB/wQIMAYBAf8CAQEwGQYDVR0RBBIwEIIOY2EuZXhhbXBs
-                ZS5jb20wCgYIKoZIzj0EAwIDSQAwRgIhAJLASYXdk77YGrVeuj2bdy48fFeGcHwY
-                hEt3dD1GqdqkAiEAqekBRTF9wzJ/lPmRJyPdLoxzGBbIkd53NCtGUfNvaL0=
-                -----END CERTIFICATE-----
+          ca.example.com:
+            - |
+              -----BEGIN CERTIFICATE-----
+              MIIDfzCCAmegAwIBAgIUN3niXMK8XOjhIvf6EUD4sz80XIkwDQYJKoZIhvcNAQEL
+              BQAwTjEpMCcGA1UEAwwgaHR0cHM6Ly9pbnRlcm1lZGlhdGUuZXhhbXBsZS5uZXQx
+              FDASBgNVBAoMC0V4YW1wbGUgSU5UMQswCQYDVQQGEwJJVDAeFw0yNTA0MDMxNTQ3
+              NTZaFw0yNjA0MDQxNTQ3NTZaMFcxMTAvBgNVBAMMKENOPWVhZi5leGFtcGxlLmNv
+              bSwgTz1FeGFtcGxlIExlYWYsIEM9SVQxFTATBgNVBAoMDEV4YW1wbGUgTGVhZjEL
+              MAkGA1UEBhMCSVQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCw/qO3
+              VfAkTQkMrHLgHuvcl1vxbptJGhW6fKNYyCXkhp+oXAewmViAIBY95OsAv6LKN2dY
+              LVywe5OpaN2d0Mv6ioRquuqgMDJxWR8VNRMPzX/BWFZTMDDGFAeJPs9NQixXub1U
+              aV8L+R0KlCXkJwrXLHadDUpupY5XX/lacyCc38Sk2bO2RkOcmYp51V245vZ0pbCc
+              tLd9wa9TFdzzsOMDMLa9+BBKhB9cBlvAi3JLo6KcWJScHFG+31ljYhqmMjX7DAMo
+              p5Guo8L59XahZOsyqhgC8gOd/0CMocBsjDurfTX7v55pQwXWFW0DPVd5e8ynTArz
+              +5Kj1WC/W8eEGk7BAgMBAAGjTDBKMAwGA1UdEwEB/wQCMAAwOgYDVR0RBDMwMYIQ
+              bGVhZi5leGFtcGxlLm9yZ4YdaHR0cHM6Ly9leGFtcGxlLmNvbS9PcGVuSUQ0VlAw
+              DQYJKoZIhvcNAQELBQADggEBACF2aoCODW4tziNQs41C9N363xYPt21uIQy0CQ24
+              1hRZ8Ev6yIQ/WORfzciLHZsWizZdS3D5oDY7K+WAgMpDSR0Ah9dXMfJjOxcUib57
+              Zh+YOi443fjU/5/DBHyHgfEvDy1QXXHJuDbgchzAv9u8uY0ibUb/GHy4OKaj9bOI
+              8g6qgZtT2wkfdHQPX+fpwZueTaHhoXJV+JTuE227fIjLZ5ThbvO0xbE3q4I/v+Gu
+              ZZ713LQaG2RwdJWTimJUi6Sro5s0YR6qRGejHmiS1FbJOOG4AAE4PkhkxVogItVE
+              Z4nqCEfD1RT6iwiWyXIYh3cNpWvcE3t4j7e/Su5IhW/Cv2E=
+              -----END CERTIFICATE-----
+            - |
+              -----BEGIN CERTIFICATE-----
+              MIIDRDCCAiygAwIBAgIUUOBXQmkRjQvfhU1YJbMEOMnPxvQwDQYJKoZIhvcNAQEL
+              BQAwUjEuMCwGA1UEAwwlQ049Y2EuZXhhbXBsZS5jb20sIE89RXhhbXBsZSBDQSwg
+              Qz1JVDETMBEGA1UECgwKRXhhbXBsZSBDQTELMAkGA1UEBhMCSVQwHhcNMjUwNDAz
+              MTU0NzU2WhcNMjYwNDA0MTU0NzU2WjBOMSkwJwYDVQQDDCBodHRwczovL2ludGVy
+              bWVkaWF0ZS5leGFtcGxlLm5ldDEUMBIGA1UECgwLRXhhbXBsZSBJTlQxCzAJBgNV
+              BAYTAklUMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsSUAY+mCs1eB
+              /hWKtF0kncwTRn3jgczjZWmUSSBZT3PzqmD9uqlgEBrv2sOGwO4bBDnutCAHhfnl
+              2gXifvg2PJHQWu/g1kVY396K+d91nrqQhUabo2cpEca66t7InPMnXkMR5DG6rNP6
+              l05OLKQIvoTaHzef0rAS4f+5gF7IcRtGq9G8QRnd2lwLmDYRPKY3jp/uvLosOatv
+              Nx5p2XtxETgOSv4GEtjax3jxkMDIIPrHwTJGWwsGvasEI5lQ/G67OjFZjjSaoJ95
+              SSPhXoIydmOmXKDN3GY7ZqT9HntuSzyB3GZ4DMLyOdZdvYvt08hUCJnnY0kGhhtW
+              gW0xb/wyKwIDAQABoxYwFDASBgNVHRMBAf8ECDAGAQH/AgEAMA0GCSqGSIb3DQEB
+              CwUAA4IBAQBAwwumBWSI/guarZsNd8hEOVZ7dWRQDLxfDZB1jKtgqA2jCEbNGwpY
+              41NRRfkTi9EfZXXVdbk9xrjNWVsGdDn/Kh/1/b4uatu2ocRG5R3e2KkZMaK1/Ru2
+              LFP6gvi7i8dvEr8IQqlg+CrEb11CjMXZi36jRZhtSUnUfmUR4hqCN/qzALdiKvHS
+              NpEu0D6x6l7YEhwtpX7bvWdnEzCUrAUltMPO9pZUR1LBSPTCMSd+vUhJw/84EJEg
+              D6Lw8OxzYyzSNOrGTqfplqlHrD/WpI6DB6Yq4Rpefz84AWraGVtZbYAlQMyK1EKS
+              C3Lef0OGQC0anzAXDsGr1As8HdEuSngu
+              -----END CERTIFICATE-----
+            - |
+              -----BEGIN CERTIFICATE-----
+              MIIDYzCCAkugAwIBAgIUHVMNJD9vqAA4mR+QAJyEQFW4kjQwDQYJKoZIhvcNAQEL
+              BQAwUjEuMCwGA1UEAwwlQ049Y2EuZXhhbXBsZS5jb20sIE89RXhhbXBsZSBDQSwg
+              Qz1JVDETMBEGA1UECgwKRXhhbXBsZSBDQTELMAkGA1UEBhMCSVQwHhcNMjUwNDAz
+              MTU0NzU2WhcNMjYwNDA0MTU0NzU2WjBSMS4wLAYDVQQDDCVDTj1jYS5leGFtcGxl
+              LmNvbSwgTz1FeGFtcGxlIENBLCBDPUlUMRMwEQYDVQQKDApFeGFtcGxlIENBMQsw
+              CQYDVQQGEwJJVDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMf3zvlY
+              zX1DYgv9QjRusMQjSRNdZi72/ydnxO/cAQ1GsgLZ8ewqIL1CnXtIs6i2F8poUOec
+              g957xk1db6sTqEWXRi5h9IfMUFcd5G7gIbJzjXCiLSVz6m9vZlvqR7BDka1VQhuH
+              rW2xEIE6+F2lWxJ+crimea/c5VlMKBCh+gQldFq3lTu6smGUz8xl8rhleBPgTgZz
+              TO4VuVO1dOb/S4lq9twfVYCTznF9vgaNaNh3la7yjzCf+zpSTGQD8TFO8ws1SZRq
+              O0bkabW8/5XsnwFHLT2LMSPkWMgMD8r+7xef93bvbEy7SA4Hw1Iow2xIIcTDYQ7F
+              77HQ3OjkogHmhrMCAwEAAaMxMC8wEgYDVR0TAQH/BAgwBgEB/wIBATAZBgNVHREE
+              EjAQgg5jYS5leGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEApRUUxw5Dn0wd
+              lFPApjn7n/SZyx5I1XnOHOIk8aWD0KFFa1zsnONlmRDgC8EQ5XKw3nMUwvnCQUR8
+              6FmrqP5gINHdqfvWiitC0eQdDhMhIHvdfUMBicgZ0XDVjDZhD6W9A+IWwR3ySLCf
+              lZHA5JwjYhpAjMYFXwSVZklOre34zJL6CRwgIUKjc9uyGPmlnVRFTUcUqLB9Uq/U
+              dFc7XMPBAbMt1frOJRj6P1OFtubuC0INpEhzivg3+w8bXmpEN6e2hBvIjoNkgnWF
+              O6HVbDnJXTA34/I4snisJfZQ+Z9gln921+2Q27sMvyS7aBqtocDuWB0w3XZ3aCYk
+              DTEzMjUtQA==
+              -----END CERTIFICATE-----
 
         private_keys: *metadata_jwks
 

--- a/example/satosa/static/css/style.css
+++ b/example/satosa/static/css/style.css
@@ -294,11 +294,6 @@
     font-weight: 600;
 }
 
-.authz-error-title {
-    font-size: 24px;
-    font-weight: 600;
-}
-
 .it-wallet-logo{
     height: 2em;
     width: 100px !important;

--- a/example/satosa/static/css/style.css
+++ b/example/satosa/static/css/style.css
@@ -294,6 +294,11 @@
     font-weight: 600;
 }
 
+.authz-error-title {
+    font-size: 24px;
+    font-weight: 600;
+}
+
 .it-wallet-logo{
     height: 2em;
     width: 100px !important;

--- a/example/satosa/templates/authorization_error.html
+++ b/example/satosa/templates/authorization_error.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+
+{% block body %}
+<div class="py-md-5 bd-content">
+    <div class="card-wrapper card-space">
+       <div class="card card-bg no-after">
+          <div class="card-body">
+            <div class="row bg-danger">
+                <p id="content-title" class="authz-error-title text-center">Errore di Autenticazione</p>
+            </div>
+            <div id="content">
+                <div id="content-text" class="row">
+                    Il tuo dispositivo Wallet ha rifiutato la richiesta di autenticazione con il seguente messaggio di errore.
+                </div>
+                <div id="content-err-text" class="row">
+                    Errore: {{ error }}
+                </div>
+                <div id="content-err-desc-text" class="row">
+                    Descrizione dell'errore: {{ error_description }}
+                </div>
+                <div id="button-home-row" class="row">
+                    <div class="text-center button-container mt-2">
+                        <a href="/" 
+                        class="btn btn-primary" 
+                        aria-haspopup="false" 
+                        aria-expanded="false" 
+                        data-focus-mouse="false"
+                        >
+                            <span>Vai alla home</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div> 
+</div>
+
+{% endblock body %}

--- a/example/satosa/templates/authorization_error.html
+++ b/example/satosa/templates/authorization_error.html
@@ -8,12 +8,10 @@
                 <div class="card border mb-4">
                   <div class="card-body">
                     <div class="categoryicon-top">
-                      <svg class="icon"><use href="/bootstrap-italia/svg/sprites.svg#it-error"></use></svg>
+                      <svg class="icon icon-danger"><use href="/bootstrap-italia/svg/sprites.svg#it-error"></use></svg>
                       <span class="text">Authentication Failure</span>
                     </div>
-                    <a href="#">
-                      <h3 class="card-title h5">Authentication Failed or Rejected by the Wallet Application</h3>
-                    </a>
+                    <h3 class="card-title h5 text-danger">Authentication Failed or Rejected by the Wallet Application</h3>
                     <p class="card-text font-serif">
                         The authentication procedure failed. The most likely cause is that the Wallet rejected your Authentication Request or that you denied to share mandatory attributes required by the service for its full functionalities.
                     </p>

--- a/example/satosa/templates/authorization_error.html
+++ b/example/satosa/templates/authorization_error.html
@@ -24,12 +24,12 @@
                         <ul class="it-list">
                             <li class="list-item">
                               <div class="it-right-zone">
-                                <span class="card-text">Error: {{ error }} </span>
+                                <span class="card-text">Error: {% if error != None %} {{ error }} {% else %} unknown error {% endif %}</span>
                               </div>
                             </li>
                             <li class="list-item">
                               <div class="it-right-zone">
-                                <span class="card-text">Error description: {{ error_description }} </span>
+                                <span class="card-text">Error description: {% if error_description != None %} {{ error_description }} {% else %} unknown error description {% endif %}</span>
                               </div>
                             </li>
                         </ul>

--- a/example/satosa/templates/authorization_error.html
+++ b/example/satosa/templates/authorization_error.html
@@ -1,38 +1,44 @@
 {% extends "base.html" %}
 
 {% block body %}
-<div class="py-md-5 bd-content">
-    <div class="card-wrapper card-space">
-       <div class="card card-bg no-after">
-          <div class="card-body">
-            <div class="row bg-danger">
-                <p id="content-title" class="authz-error-title text-center">Errore di Autenticazione</p>
-            </div>
-            <div id="content">
-                <div id="content-text" class="row">
-                    Il tuo dispositivo Wallet ha rifiutato la richiesta di autenticazione con il seguente messaggio di errore.
-                </div>
-                <div id="content-err-text" class="row">
-                    Errore: {{ error }}
-                </div>
-                <div id="content-err-desc-text" class="row">
-                    Descrizione dell'errore: {{ error_description }}
-                </div>
-                <div id="button-home-row" class="row">
-                    <div class="text-center button-container mt-2">
-                        <a href="/" 
-                        class="btn btn-primary" 
-                        aria-haspopup="false" 
-                        aria-expanded="false" 
-                        data-focus-mouse="false"
-                        >
-                            <span>Vai alla home</span>
-                        </a>
+<div class="container-sm">
+    <div class="row mt-2 mt-md-4 justify-content-center">
+        <div class="col-xl-5 col-lg-6 col-md-8 col-sm-10">
+            <div class="card-wrapper">
+                <div class="card border mb-4">
+                  <div class="card-body">
+                    <div class="categoryicon-top">
+                      <svg class="icon"><use href="/bootstrap-italia/svg/sprites.svg#it-error"></use></svg>
+                      <span class="text">Authentication Failure</span>
                     </div>
+                    <a href="#">
+                      <h3 class="card-title h5">Authentication Failed or Rejected by the Wallet Application</h3>
+                    </a>
+                    <p class="card-text font-serif">
+                        The authentication procedure failed. The most likely cause is that the Wallet rejected your Authentication Request or that you denied to share mandatory attributes required by the service for its full functionalities.
+                    </p>
+                    <p class="card-text font-serif">
+                        This is the error message sent by the Wallet application:
+                    </p>
+                    <div class="it-list-wrapper">
+                        <ul class="it-list">
+                            <li class="list-item">
+                              <div class="it-right-zone">
+                                <span class="card-text">Error: {{ error }} </span>
+                              </div>
+                            </li>
+                            <li class="list-item">
+                              <div class="it-right-zone">
+                                <span class="card-text">Error description: {{ error_description }} </span>
+                              </div>
+                            </li>
+                        </ul>
+                      </div>
+                  </div>
                 </div>
-            </div>
+              </div>
         </div>
-    </div> 
-</div>
+    </div>
+  </div>
 
 {% endblock body %}

--- a/pyeudiw/openid4vp/schemas/response.py
+++ b/pyeudiw/openid4vp/schemas/response.py
@@ -55,8 +55,9 @@ class AuthorizeResponsePayload:
     vp_token: str | list[str]
     presentation_submission: dict
 
+
 @dataclass
 class ErrorResponsePayload:
     state: str
     error: str
-    error_description: str
+    error_description: str | None = None

--- a/pyeudiw/satosa/default/openid4vp_backend.py
+++ b/pyeudiw/satosa/default/openid4vp_backend.py
@@ -343,9 +343,7 @@ class OpenID4VPBackend(OpenID4VPBackendInterface, BaseLogger):
         if "error_response" in finalized_session:
             return self._get_response_authorization_error_page(finalized_session["error_response"])
         if "internal_response" in finalized_session:
-            internal_response = InternalData()
-            resp = internal_response.from_dict(finalized_session["internal_response"])
-            return self.auth_callback_func(context, resp)
+            return self._get_response_auth_callback(context, finalized_session["internal_response"])
 
         return self._handle_500(
             context,
@@ -356,9 +354,14 @@ class OpenID4VPBackend(OpenID4VPBackendInterface, BaseLogger):
     def _get_response_authorization_error_page(self, wallet_error_response: dict):
         # TODO: le informazioni di fallaback andrebbero gestite dalla view, non dal controller, motivi i multilingua etc
         return self.template.authorization_error_response_page.render({
-            "error": wallet_error_response.get("error", "unknown error"),
-            "error_description": wallet_error_response.get("error_description", "unknown error details")
+            "error": wallet_error_response.get("error"),
+            "error_description": wallet_error_response.get("error_description")
         })
+
+    def _get_response_auth_callback(self, context, internal_resp_data: dict):
+        internal_response = InternalData()
+        resp = internal_response.from_dict(internal_resp_data)
+        return self.auth_callback_func(context, resp)
 
     def status_endpoint(self, context: Context) -> JsonResponse:
         """

--- a/pyeudiw/satosa/default/openid4vp_backend.py
+++ b/pyeudiw/satosa/default/openid4vp_backend.py
@@ -408,25 +408,25 @@ class OpenID4VPBackend(OpenID4VPBackendInterface, BaseLogger):
         request_object = session.get("request_object", None)
         if request_object:
             if iat_now() > request_object["exp"]:
-                return self._status_session_expired(context)
+                return self._status_session_expired_response(context)
 
         if session["finalized"]:
             if session.get("error_response"):
-                return self._status_session_finished_error(context, session["error_response"])
-            return self._status_session_finished_ok(state)
+                return self._status_session_finished_error_response(context, session["error_response"])
+            return self._status_session_finished_ok_response(state)
 
         if request_object is not None:
-            return self._status_session_accepted()
+            return self._status_session_accepted_response()
 
-        return self._status_session_created()
+        return self._status_session_created_response()
 
-    def _status_session_expired(self, context) -> Response:
+    def _status_session_expired_response(self, context) -> Response:
         return self._handle_403(
             context,
             "request error: request expired",
         )
 
-    def _status_session_finished_ok(self, state: str) -> Response:
+    def _status_session_finished_ok_response(self, state: str) -> Response:
         resp_code = self.response_code_helper.create_code(state)
         return JsonResponse(
             {
@@ -435,7 +435,7 @@ class OpenID4VPBackend(OpenID4VPBackendInterface, BaseLogger):
             status="200",
         )
 
-    def _status_session_finished_error(self, context, wallet_error: dict) -> Response:
+    def _status_session_finished_error_response(self, context, wallet_error: dict) -> Response:
         self._log_error(
             context,
             f"the wallet rejected the authentication attempt and responsed with the following Authorization Response Error: {wallet_error}"
@@ -448,10 +448,10 @@ class OpenID4VPBackend(OpenID4VPBackendInterface, BaseLogger):
             status="401"
         )
 
-    def _status_session_accepted(self) -> Response:
+    def _status_session_accepted_response(self) -> Response:
         return JsonResponse({"response": "Accepted"}, status="202")
 
-    def _status_session_created(self) -> Response:
+    def _status_session_created_response(self) -> Response:
         return JsonResponse({"response": "Request object issued"}, status="201")
 
     @property

--- a/pyeudiw/satosa/default/openid4vp_backend.py
+++ b/pyeudiw/satosa/default/openid4vp_backend.py
@@ -352,7 +352,6 @@ class OpenID4VPBackend(OpenID4VPBackendInterface, BaseLogger):
         )
 
     def _get_response_authorization_error_page(self, wallet_error_response: dict):
-        # TODO: le informazioni di fallaback andrebbero gestite dalla view, non dal controller, motivi i multilingua etc
         return self.template.authorization_error_response_page.render({
             "error": wallet_error_response.get("error"),
             "error_description": wallet_error_response.get("error_description")

--- a/pyeudiw/satosa/utils/html_template.py
+++ b/pyeudiw/satosa/utils/html_template.py
@@ -33,3 +33,4 @@ class Jinja2TemplateHandler:
         )
 
         self.qrcode_page = self.loader.get_template(config["qrcode_template"])
+        self.authorization_error_response_page = self.loader.get_template(config["authorization_error_template"])

--- a/pyeudiw/tests/satosa/templates/authorization_error.html
+++ b/pyeudiw/tests/satosa/templates/authorization_error.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block body %}
+<div class="container-sm">
+    <div class="row mt-2 mt-md-4 justify-content-center">
+        <div class="col-xl-5 col-lg-6 col-md-8 col-sm-10">
+            <div class="card-wrapper">
+                <div class="card border mb-4">
+                  <div class="card-body">
+                    <div class="categoryicon-top">
+                      <svg class="icon icon-danger"><use href="/bootstrap-italia/svg/sprites.svg#it-error"></use></svg>
+                      <span class="text">Authentication Failure</span>
+                    </div>
+                    <h3 class="card-title h5 text-danger">Authentication Failed or Rejected by the Wallet Application</h3>
+                    <p class="card-text font-serif">
+                        The authentication procedure failed. The most likely cause is that the Wallet rejected your Authentication Request or that you denied to share mandatory attributes required by the service for its full functionalities.
+                    </p>
+                    <p class="card-text font-serif">
+                        This is the error message sent by the Wallet application:
+                    </p>
+                    <div class="it-list-wrapper">
+                        <ul class="it-list">
+                            <li class="list-item">
+                              <div class="it-right-zone">
+                                <span class="card-text">Error: {% if error != None %} {{ error }} {% else %} unknown error {% endif %}</span>
+                              </div>
+                            </li>
+                            <li class="list-item">
+                              <div class="it-right-zone">
+                                <span class="card-text">Error description: {% if error_description != None %} {{ error_description }} {% else %} unknown error description {% endif %}</span>
+                              </div>
+                            </li>
+                        </ul>
+                      </div>
+                  </div>
+                </div>
+              </div>
+        </div>
+    </div>
+  </div>
+
+{% endblock body %}

--- a/pyeudiw/tests/settings.py
+++ b/pyeudiw/tests/settings.py
@@ -133,6 +133,7 @@ CONFIG = {
         "template_folder": f"{pathlib.Path().absolute().__str__()}/pyeudiw/tests/satosa/templates",
         "qrcode_template": "qrcode.html",
         "error_url": "https://localhost:9999/error_page.html",
+        "authorization_error_template": "authorization_error.html"
     },
     "endpoints": {
         "pre_request": "/pre-request",


### PR DESCRIPTION
This PR is **PARTIAL** attempt at dealing with #378. The goal of this PR is to provide a **minimal** working error error management for cases when the user denies the authentication request.

Implementation details as follows in scenarios where the wallet sends an authorization error response.
1. The status endpoint was updated to return 401 errors. As a consequence, the page with a QR code and polling javascript will update accordingly (relevant for cross device flow).
2. The redirect_uri leads to a generic error page¹ signaling that the authentication was canceled or failed (relevant for same device flow).
3. Suggestions proposed here https://github.com/italia/eudi-wallet-it-python/issues/378#issuecomment-2790346402 were not taken into account

A new integration test was added to test this case, as such **THIS PR MIGHT GENERATE CONFLICT WITH SOMEONE DEALING WITH #408 **.

¹ It is ugly and not very usable, and should be treated as a proof of concept.
