### PR TITLE
trust header (including x5c) rework

### DIFF
--- a/example/satosa/pyeudiw_backend.yaml
+++ b/example/satosa/pyeudiw_backend.yaml
@@ -209,6 +209,7 @@ config:
         httpc_params: *httpc_params
         cache_ttl: 0
         entity_configuration_exp: 600
+        # include_issued_jwt_header_param: true # default false; if true, it will include trust_chain header parameters in the signed presentation request issued by this trust handler
         metadata_type: "openid_credential_verifier"
         metadata: *metadata
         authority_hints:
@@ -248,6 +249,7 @@ config:
       config:
         # client_id: *client_id
         client_id_scheme: x509_san_dns # this will be prepended in the client id scheme used in the request. 
+        include_issued_jwt_header_param: true # default false; if true, it will include x5c header parameters in the signed presentation request issued by this trust handler
         certificate_authorities:
           - ca.example.com: |
                 -----BEGIN CERTIFICATE-----

--- a/example/satosa/pyeudiw_backend.yaml
+++ b/example/satosa/pyeudiw_backend.yaml
@@ -248,6 +248,7 @@ config:
       config:
         # client_id: *client_id
         client_id_scheme: x509_san_dns # this will be prepended in the client id scheme used in the request. 
+        include_issued_jwt_header_param: true # default false; if true, it will include x5c header parameters in the signed presentation request issued by this trust handler
         certificate_authorities:
           - ca.example.com: |
                 -----BEGIN CERTIFICATE-----

--- a/example/satosa/pyeudiw_backend.yaml
+++ b/example/satosa/pyeudiw_backend.yaml
@@ -248,7 +248,6 @@ config:
       config:
         # client_id: *client_id
         client_id_scheme: x509_san_dns # this will be prepended in the client id scheme used in the request. 
-        include_issued_jwt_header_param: true # default false; if true, it will include x5c header parameters in the signed presentation request issued by this trust handler
         certificate_authorities:
           - ca.example.com: |
                 -----BEGIN CERTIFICATE-----

--- a/pyeudiw/jwk/parse.py
+++ b/pyeudiw/jwk/parse.py
@@ -1,3 +1,4 @@
+import base64
 from cryptojwt.jwk.ec import import_ec_key, ECKey
 from cryptojwt.jwk.rsa import RSAKey, import_rsa_key
 from ssl import DER_cert_to_PEM_cert
@@ -62,6 +63,15 @@ def parse_certificate(cert: str | bytes) -> JWK:
         cert = DER_cert_to_PEM_cert(cert)
 
     return parse_pem(cert)
+
+
+def parse_b64der(b64der: str) -> JWK:
+    """
+    Parse a (public) key from a Base64 encoded DER certificate.
+    """
+    der = base64.b64decode(b64der)
+    return parse_certificate(der)
+
 
 def parse_x5c_keys(x5c: list[str]) -> list[JWK]:
     """

--- a/pyeudiw/satosa/default/request_handler.py
+++ b/pyeudiw/satosa/default/request_handler.py
@@ -98,6 +98,7 @@ class RequestHandler(RequestHandlerInterface, BaseLogger):
                 data,
                 protected=_protected_jwt_headers,
             )
+            self._log_debug(context, f"created request object {request_object_jwt}")
             return Response(
                 message=request_object_jwt,
                 status="200",

--- a/pyeudiw/satosa/default/request_handler.py
+++ b/pyeudiw/satosa/default/request_handler.py
@@ -5,8 +5,7 @@ from pyeudiw.openid4vp.authorization_request import build_authorization_request_
 from pyeudiw.satosa.interfaces.request_handler import RequestHandlerInterface
 from pyeudiw.satosa.utils.response import Response
 from pyeudiw.tools.base_logger import BaseLogger
-from pyeudiw.jwt.exceptions import JWSSigningError
-from pyeudiw.jwk.parse import parse_certificate
+from pyeudiw.jwk.parse import parse_b64der
 from pyeudiw.jwk import JWK
 
 
@@ -75,7 +74,8 @@ class RequestHandler(RequestHandlerInterface, BaseLogger):
         metadata_key = None
 
         if "x5c" in _protected_jwt_headers:
-            jwk = parse_certificate(_protected_jwt_headers["x5c"][0])
+            # TODO: move this logic in the JWS signer...
+            jwk = parse_b64der(_protected_jwt_headers["x5c"][0])
 
             for key in self.config["metadata_jwks"]:
                 if JWK(key).thumbprint == jwk.thumbprint:

--- a/pyeudiw/tests/federation/base.py
+++ b/pyeudiw/tests/federation/base.py
@@ -29,17 +29,17 @@ leaf_cred_jwk_prot = new_ec_key(ec_crv, alg=ec_alg)
 leaf_cred = {
     "exp": EXP,
     "iat": NOW,
-    "iss": "https://credential_issuer.example.org",
-    "sub": "https://credential_issuer.example.org",
+    "iss": "https://credential-issuer.example.org",
+    "sub": "https://credential-issuer.example.org",
     "jwks": {"keys": []},
     "metadata": {
         "openid_credential_issuer": {"jwks": {"keys": []}},
         "federation_entity": {
             "organization_name": "OpenID Credential Issuer example",
-            "homepage_uri": "https://credential_issuer.example.org/home",
-            "policy_uri": "https://credential_issuer.example.org/policy",
-            "logo_uri": "https://credential_issuer.example.org/static/logo.svg",
-            "contacts": ["tech@credential_issuer.example.org"],
+            "homepage_uri": "https://credential-issuer.example.org/home",
+            "policy_uri": "https://credential-issuer.example.org/policy",
+            "logo_uri": "https://credential-issuer.example.org/static/logo.svg",
+            "contacts": ["tech@credential-issuer.example.org"],
         },
     },
     "authority_hints": ["https://intermediate.eidas.example.org"],
@@ -55,7 +55,7 @@ intermediate_es_cred = {
     "exp": EXP,
     "iat": NOW,
     "iss": "https://intermediate.eidas.example.org",
-    "sub": "https://credential_issuer.example.org",
+    "sub": "https://credential-issuer.example.org",
     "jwks": {"keys": []},
 }
 intermediate_es_cred["jwks"]["keys"] = [leaf_cred_jwk.serialize()]

--- a/pyeudiw/tests/satosa/test_backend.py
+++ b/pyeudiw/tests/satosa/test_backend.py
@@ -897,7 +897,7 @@ class TestOpenID4VPBackend:
         # msg = json.loads(state_endpoint_response.message)
         # assert msg["response"] == "Authentication successful"
 
-    def test_trust_patameters_in_response(self, context):
+    def test_trust_parameters_in_response(self, context):
         internal_data = InternalData()
         context.http_headers = dict(
             HTTP_USER_AGENT="Mozilla/5.0 (Linux; Android 10; SM-G960F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36"
@@ -913,7 +913,7 @@ class TestOpenID4VPBackend:
 
         tsd = TrustSourceData.empty(CREDENTIAL_ISSUER_ENTITY_ID)
         tsd.add_trust_param(
-            "trust_chain",
+            "federation",
             TrustEvaluationType(
                 attribute_name="trust_chain",
                 jwks=[JWK(key=ta_jwk).as_dict()],

--- a/pyeudiw/tests/satosa/test_backend.py
+++ b/pyeudiw/tests/satosa/test_backend.py
@@ -467,7 +467,6 @@ class TestOpenID4VPBackend:
 
         # case (4): good aud, nonce and state
         good_response = self._generate_payload(self.issuer_jwk, self.holder_jwk, nonce, state, self.backend.client_id)
-
         encrypted_response = JWEHelper(
             CONFIG["metadata_jwks"][1]).encrypt(good_response)
         context.request = {
@@ -919,6 +918,7 @@ class TestOpenID4VPBackend:
                 jwks=[JWK(key=ta_jwk).as_dict()],
                 expiration_date=datetime.datetime.now(),
                 trust_chain=trust_chain_wallet,
+                trust_handler_name="FederationHandler",
             )
         )
 

--- a/pyeudiw/tests/settings.py
+++ b/pyeudiw/tests/settings.py
@@ -268,6 +268,7 @@ CONFIG = {
                         ta_jwk.serialize(private=False),
                     ]
                 },
+                "include_issued_jwt_header_param": True,
                 "default_sig_alg": "RS256",
                 "federation_jwks": [
                     jwk,
@@ -310,6 +311,7 @@ CONFIG = {
             "class": "X509Handler",
             "config": {
                 "client_id": f"{BASE_URL}/OpenID4VP",
+                "include_issued_jwt_header_param": True,
                 "relying_party_certificate_chains_by_ca":{
                     "ca.example.com": DEFAULT_X509_CHAIN,
                 },

--- a/pyeudiw/tests/trust/mock_trust_handler.py
+++ b/pyeudiw/tests/trust/mock_trust_handler.py
@@ -75,6 +75,9 @@ class MockTrustHandler(TrustHandlerInterface):
         trust_source.add_trust_param("test_trust_param", trust_param)
 
         return trust_source
+    
+    def extract_jwt_header_trust_parameters(self, trust_source: TrustSourceData) -> dict:
+        return {'trust_param_name': trust_source.test_trust_param.trust_param_name}
 
 class UpdateTrustHandler(MockTrustHandler):
     """
@@ -107,6 +110,9 @@ class UpdateTrustHandler(MockTrustHandler):
         trust_source.add_trust_param("test_trust_param", trust_param)
 
         return trust_source
+
+    def extract_jwt_header_trust_parameters(self, trust_source: TrustSourceData) -> dict:
+        return {'trust_param_name': trust_source.test_trust_param.trust_param_name}
 
 class NonConformatTrustHandler:
     def get_metadata(self, issuer: str, trust_source: TrustSourceData) -> dict:

--- a/pyeudiw/tests/trust/mock_trust_handler.py
+++ b/pyeudiw/tests/trust/mock_trust_handler.py
@@ -32,6 +32,7 @@ class MockTrustHandler(TrustHandlerInterface):
     def __init__(self, *args, **kwargs):
         self.client_id = kwargs.get("default_client_id", None)
         self.exp = kwargs.get("exp", 10)
+        self.include_issued_jwt_header_param = kwargs.get("include_issued_jwt_header_param", False)
 
     def get_metadata(self, issuer: str, trust_source: TrustSourceData) -> dict:
         if issuer == self.client_id:

--- a/pyeudiw/tests/trust/test_dynamic.py
+++ b/pyeudiw/tests/trust/test_dynamic.py
@@ -52,14 +52,13 @@ def test_public_key_and_metadata_retrive():
             "mock": {
                 "module": "pyeudiw.tests.trust.mock_trust_handler",
                 "class": "MockTrustHandler",
-                "config": {},
+                "config": {"include_issued_jwt_header_param": True},
             },
                 
         }, db_engine, default_client_id="default-client-id", mode="update_first"
     )
 
     uuid_url = f"http://{uuid4()}.issuer.it"
-
     assert trust_ev.get_jwt_header_trust_parameters(uuid_url) == {'trust_param_name': {'trust_param_key': 'trust_param_value'}}
     metadata = trust_ev.get_metadata()
 
@@ -82,7 +81,7 @@ def test_update_first_strategy():
             "mock": {
                 "module": "pyeudiw.tests.trust.mock_trust_handler",
                 "class": "UpdateTrustHandler",
-                "config": {},
+                "config":  {"include_issued_jwt_header_param": True},
             },
                 
         }, db_engine, default_client_id="default-client-id"
@@ -102,7 +101,7 @@ def test_cache_first_strategy():
             "mock": {
                 "module": "pyeudiw.tests.trust.mock_trust_handler",
                 "class": "UpdateTrustHandler",
-                "config": {},
+                "config":  {"include_issued_jwt_header_param": True},
             },
                 
         }, db_engine, default_client_id="default-client-id", mode="cache_first"
@@ -122,7 +121,8 @@ def test_cache_first_strategy_expired():
                 "module": "pyeudiw.tests.trust.mock_trust_handler",
                 "class": "UpdateTrustHandler",
                 "config": {
-                    "exp": 0
+                    "exp": 0,
+                    "include_issued_jwt_header_param": True
                 },
             },
                 
@@ -143,7 +143,7 @@ def test_cache_first_strategy_expired_revoked():
             "mock": {
                 "module": "pyeudiw.tests.trust.mock_trust_handler",
                 "class": "UpdateTrustHandler",
-                "config": {},
+                "config": {"include_issued_jwt_header_param": True},
             },
                 
         }, db_engine, default_client_id="default-client-id", mode="cache_first"
@@ -166,7 +166,7 @@ def test_cache_first_strategy_expired_force_update():
             "mock": {
                 "module": "pyeudiw.tests.trust.mock_trust_handler",
                 "class": "UpdateTrustHandler",
-                "config": {},
+                "config":  {"include_issued_jwt_header_param": True},
             },
                 
         }, db_engine, default_client_id="default-client-id", mode="cache_first"

--- a/pyeudiw/trust/dynamic.py
+++ b/pyeudiw/trust/dynamic.py
@@ -19,6 +19,8 @@ logger = logging.getLogger(__name__)
 
 UpsertMode = Union[Literal["update_first"], Literal["cache_first"]]
 
+INCLUDE_JWT_HEADER_CONFIG_NAME = "include_issued_jwt_header_param"
+
 
 class CombinedTrustEvaluator(BaseLogger):
     """
@@ -308,9 +310,9 @@ class CombinedTrustEvaluator(BaseLogger):
         headers_params = {}
 
         for handler in self.handlers:
-            header = handler.extract_jwt_header_trust_parameters(trust_source)
-            if header:
-                headers_params.update(header)
+            if getattr(handler, INCLUDE_JWT_HEADER_CONFIG_NAME, None):
+                if header := handler.extract_jwt_header_trust_parameters(trust_source):
+                    headers_params.update(header)
         return headers_params
 
     def build_metadata_endpoints(

--- a/pyeudiw/trust/dynamic.py
+++ b/pyeudiw/trust/dynamic.py
@@ -308,7 +308,6 @@ class CombinedTrustEvaluator(BaseLogger):
         trust_source = self._get_trust_source(issuer, force_update)
 
         headers_params = {}
-
         for handler in self.handlers:
             if getattr(handler, INCLUDE_JWT_HEADER_CONFIG_NAME, None):
                 if header := handler.extract_jwt_header_trust_parameters(trust_source):

--- a/pyeudiw/trust/dynamic.py
+++ b/pyeudiw/trust/dynamic.py
@@ -199,7 +199,7 @@ class CombinedTrustEvaluator(BaseLogger):
                         else:
                             used_handlers.append(handler.__class__.__name__)
 
-            self._log_warning(f"no configured trust handler can successfully process static trust material {static_trust_materials} of issuer {issuer}")
+            self._log_warning("static trust evaluation", f"no configured trust handler can successfully process static trust material {static_trust_materials} of issuer {issuer}")
 
         # try with handlers that don't use static trust materials like DirectTrustJar
         filetered_handlers = [handler for handler in self.handlers if handler.__class__.__name__ not in used_handlers]

--- a/pyeudiw/trust/dynamic.py
+++ b/pyeudiw/trust/dynamic.py
@@ -308,14 +308,12 @@ class CombinedTrustEvaluator(BaseLogger):
         """
         trust_source = self._get_trust_source(issuer, force_update)
 
-        excluded_fields = ["entity_id", "policies", "metadata", "revoked"]
-
         headers_params = {}
 
-        for param_name, param_value in trust_source.serialize().items():
-            if param_name not in excluded_fields:
-                headers_params[param_value["attribute_name"]] = param_value[param_value["attribute_name"]]
-
+        for handler in self.handlers:
+            header = handler.get_jwt_header_trust_parameters(trust_source)
+            if header:
+                headers_params.update(header)
         return headers_params
 
     def build_metadata_endpoints(

--- a/pyeudiw/trust/dynamic.py
+++ b/pyeudiw/trust/dynamic.py
@@ -199,10 +199,7 @@ class CombinedTrustEvaluator(BaseLogger):
                         else:
                             used_handlers.append(handler.__class__.__name__)
 
-            raise NoCriptographicMaterial(
-                f"no trust evaluator can provide cyptographic material "
-                f"for {issuer}: searched among: {self.handlers_names}"
-            )
+            self._log_warning(f"no configured trust handler can successfully process static trust material {static_trust_materials} of issuer {issuer}")
 
         # try with handlers that don't use static trust materials like DirectTrustJar
         filetered_handlers = [handler for handler in self.handlers if handler.__class__.__name__ not in used_handlers]

--- a/pyeudiw/trust/dynamic.py
+++ b/pyeudiw/trust/dynamic.py
@@ -311,7 +311,7 @@ class CombinedTrustEvaluator(BaseLogger):
         headers_params = {}
 
         for handler in self.handlers:
-            header = handler.get_jwt_header_trust_parameters(trust_source)
+            header = handler.extract_jwt_header_trust_parameters(trust_source)
             if header:
                 headers_params.update(header)
         return headers_params

--- a/pyeudiw/trust/handler/_direct_trust_jwk.py
+++ b/pyeudiw/trust/handler/_direct_trust_jwk.py
@@ -246,7 +246,7 @@ class _DirectTrustJwkHandler(TrustHandlerInterface, BaseLogger):
         # this class does not handle generic metadata information: it fetches and exposes cryptographic material only
         return trust_source
 
-    def get_jwt_header_trust_parameters(self, trust_source: TrustSourceData) -> dict:
+    def extract_jwt_header_trust_parameters(self, trust_source: TrustSourceData) -> dict:
         """
         Direct Trust is not formally associated to any trust parameter
         """

--- a/pyeudiw/trust/handler/_direct_trust_jwk.py
+++ b/pyeudiw/trust/handler/_direct_trust_jwk.py
@@ -246,6 +246,12 @@ class _DirectTrustJwkHandler(TrustHandlerInterface, BaseLogger):
         # this class does not handle generic metadata information: it fetches and exposes cryptographic material only
         return trust_source
 
+    def get_jwt_header_trust_parameters(self, trust_source: TrustSourceData) -> dict:
+        """
+        Direct Trust is not formally associated to any trust parameter
+        """
+        return {}
+
 
 def build_jwk_issuer_endpoint(issuer_id: str, endpoint_component: str, conform: bool = True) -> str:
     if not endpoint_component:

--- a/pyeudiw/trust/handler/_direct_trust_jwk.py
+++ b/pyeudiw/trust/handler/_direct_trust_jwk.py
@@ -1,3 +1,5 @@
+import re
+import requests
 from typing import Any, Callable, Literal
 from urllib.parse import urlparse
 
@@ -100,9 +102,11 @@ class _DirectTrustJwkHandler(TrustHandlerInterface, BaseLogger):
         if jwks:
             # get jwks by value
             return jwks
-        return self._get_jwks_by_reference(jwks_uri)
+        jwks_resp = self._get_jwks_by_reference(jwks_uri)
+        if jwks_resp and jwks_resp.status_code == 200:
+            return jwks_resp.json()
     
-    def _get_url(self, endpoint: str) -> str:
+    def _get_url(self, endpoint: str) -> requests.Response:
         if self.cache_ttl:
             resp = cacheable_get_http_url(
                 self.cache_ttl,
@@ -136,24 +140,11 @@ class _DirectTrustJwkHandler(TrustHandlerInterface, BaseLogger):
             f"failed to fetch valid jwk metadata: obtained {resp}"
         )
 
-    def _get_jwks_by_reference(self, jwks_reference_uri: str) -> dict:
+    def _get_jwks_by_reference(self, jwks_reference_uri: str) -> requests.Response:
         """
         call the jwks endpoint if jwks is defined by reference
         """
-        if self.cache_ttl:
-            resp = cacheable_get_http_url(
-                self.cache_ttl,
-                jwks_reference_uri,
-                self.httpc_params,
-                http_async=self.http_async_calls,
-            )
-        else:
-            resp = get_http_url(
-                [jwks_reference_uri],
-                self.httpc_params,
-                http_async=self.http_async_calls,
-            )[0]
-        return resp.json()
+        return self._get_url(jwks_reference_uri)
 
     def build_metadata_endpoints(
         self, backend_name: str, entity_uri: str
@@ -185,6 +176,10 @@ class _DirectTrustJwkHandler(TrustHandlerInterface, BaseLogger):
         """
         if not issuer:
             raise ValueError("invalid issuer: cannot be empty value")
+
+        if not is_url(issuer):
+            self._log_warning("Extracting JWK", f"invalid issuer: issuer should be an URL, observed instead {issuer}")
+            return trust_source
 
         try:
             self.get_metadata(issuer, trust_source)
@@ -262,3 +257,19 @@ def build_jwk_issuer_endpoint(issuer_id: str, endpoint_component: str, conform: 
     baseurl = urlparse(issuer_id)
     full_endpoint_path = f"/{endpoint_component.strip('/')}{baseurl.path}" if conform else f"{baseurl.path}/{endpoint_component.strip('/')}"
     return baseurl._replace(path=full_endpoint_path).geturl()
+
+
+# this is the regular expression that django uses for URL validation
+_is_url_regex = re.compile(
+    r'^(?:http|ftp)s?://' # http:// or https://
+    r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|' #domain...
+    r'localhost|' #localhost...
+    r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})' # ...or ip
+    r'(?::\d+)?' # optional port
+    r'(?:/?|[/?]\S+)$', re.IGNORECASE)
+
+
+def is_url(url: str) -> bool:
+    if not _is_url_regex.search(url):
+        return False
+    return True

--- a/pyeudiw/trust/handler/direct_trust_jar.py
+++ b/pyeudiw/trust/handler/direct_trust_jar.py
@@ -1,4 +1,6 @@
+from pyeudiw.jwk import JWK
 from pyeudiw.trust.handler._direct_trust_jwk import _DirectTrustJwkHandler
+from pyeudiw.trust.model.trust_source import TrustEvaluationType, TrustSourceData
 
 from .commons import DEFAULT_HTTPC_PARAMS
 
@@ -28,3 +30,43 @@ class DirectTrustJar(_DirectTrustJwkHandler):
             jwks=jwks,
             client_id=client_id,
         )
+
+    def _extract_and_update_own_trust_material(self, trust_source: TrustSourceData) -> TrustSourceData:
+        if self.jwks is None:
+            return trust_source
+
+        public_keys = [JWK(k).as_public_dict() for k in self.jwks]
+
+        trust_source.add_trust_param(
+            self.get_handled_trust_material_name(),
+            TrustEvaluationType(
+                attribute_name="jwks",
+                jwks=public_keys,
+                expiration_date=None,
+                trust_handler_name=str(self.__class__.__name__),
+            )
+        )
+        return trust_source
+
+    def extract_and_update_trust_materials(
+        self, issuer: str, trust_source: TrustSourceData
+    ) -> TrustSourceData:
+        # In the context of an OID4VP protocol flow, no-one but ourself
+        # can be trusted as a JAR issuer. As long as this is true, we have
+        # no reason to collect other parties JAR trust material.
+        if issuer != self.client_id:
+            return trust_source
+        return self._extract_and_update_own_trust_material(trust_source)
+
+    def get_metadata(
+        self, issuer: str, trust_source: TrustSourceData
+    ) -> TrustSourceData:
+        # NOTE: as of version 1 of Potential profile for OID4VP, there is
+        # no such thing as online resolution of client metadata outside of
+        # what already defined in different schemes OID4VP draft 21 section 5,
+        # where the usage of client_metadata parameter in the presentation
+        # request is suggested
+        return trust_source
+
+    def get_handled_trust_material_name(self) -> str:
+        return "direct_trust_jar"

--- a/pyeudiw/trust/handler/direct_trust_jar.py
+++ b/pyeudiw/trust/handler/direct_trust_jar.py
@@ -51,12 +51,12 @@ class DirectTrustJar(_DirectTrustJwkHandler):
     def extract_and_update_trust_materials(
         self, issuer: str, trust_source: TrustSourceData
     ) -> TrustSourceData:
+        if issuer == self.client_id:
+            return self._extract_and_update_own_trust_material(trust_source)
         # In the context of an OID4VP protocol flow, no-one but ourself
         # can be trusted as a JAR issuer. As long as this is true, we have
         # no reason to collect other parties JAR trust material.
-        if issuer != self.client_id:
-            return trust_source
-        return self._extract_and_update_own_trust_material(trust_source)
+        return trust_source
 
     def get_metadata(
         self, issuer: str, trust_source: TrustSourceData

--- a/pyeudiw/trust/handler/federation.py
+++ b/pyeudiw/trust/handler/federation.py
@@ -31,6 +31,10 @@ _ISSUER_METADATA_TYPE = "openid_credential_issuer"
 
 
 class FederationHandler(TrustHandlerInterface, BaseLogger):
+
+    _TRUST_TYPE = "federation"
+    _TRUST_PARAMETER_NAME = "trust_chain"
+
     def __init__(
         self,
         metadata: List[dict],
@@ -166,8 +170,14 @@ class FederationHandler(TrustHandlerInterface, BaseLogger):
         return [(metadata_path, metadata_response_fn)]
     
     def get_handled_trust_material_name(self) -> str:
-        return "trust_chain"
+        return FederationHandler._TRUST_PARAMETER_NAME
         
+    def get_jwt_header_trust_parameters(self, trust_source: TrustSourceData) -> dict:
+        tp: dict = trust_source.serialize().get(FederationHandler._TRUST_TYPE, {})
+        if (trust_chain := tp.get(FederationHandler._TRUST_PARAMETER_NAME, None)):
+            return {"trust_chain": trust_chain}
+        return {}
+    
     def validate_trust_material(
             self, 
             trust_chain: list[str], 
@@ -248,9 +258,9 @@ class FederationHandler(TrustHandlerInterface, BaseLogger):
 
         # the good trust chain is then stored
         trust_source.add_trust_param(
-            "federation",
+            FederationHandler._TRUST_TYPE,
             TrustEvaluationType(
-                attribute_name="trust_chain",
+                attribute_name=FederationHandler._TRUST_PARAMETER_NAME,
                 trust_chain=trust_chain,
                 jwks=[JWK(key=jwk).as_dict() for jwk in leaf_jwks],
                 expiration_date=None,

--- a/pyeudiw/trust/handler/federation.py
+++ b/pyeudiw/trust/handler/federation.py
@@ -172,7 +172,7 @@ class FederationHandler(TrustHandlerInterface, BaseLogger):
     def get_handled_trust_material_name(self) -> str:
         return FederationHandler._TRUST_PARAMETER_NAME
         
-    def get_jwt_header_trust_parameters(self, trust_source: TrustSourceData) -> dict:
+    def extract_jwt_header_trust_parameters(self, trust_source: TrustSourceData) -> dict:
         tp: dict = trust_source.serialize().get(FederationHandler._TRUST_TYPE, {})
         if (trust_chain := tp.get(FederationHandler._TRUST_PARAMETER_NAME, None)):
             return {"trust_chain": trust_chain}

--- a/pyeudiw/trust/handler/federation.py
+++ b/pyeudiw/trust/handler/federation.py
@@ -49,6 +49,7 @@ class FederationHandler(TrustHandlerInterface, BaseLogger):
         httpc_params: dict = DEFAULT_HTTPC_PARAMS,
         cache_ttl: int = 0,
         metadata_type: str = _ISSUER_METADATA_TYPE,
+        include_issued_jwt_header_param: bool = False,
         **kwargs,
     ):
 
@@ -68,6 +69,7 @@ class FederationHandler(TrustHandlerInterface, BaseLogger):
         self.federation_entity_metadata: dict[str, str] = federation_entity_metadata
         self.client_id: str = federation_entity_metadata
         self.entity_configuration_exp = entity_configuration_exp
+        self.include_issued_jwt_header_param = include_issued_jwt_header_param
 
         self.federation_public_jwks = [
             JWK(i).as_public_dict() for i in self.federation_jwks

--- a/pyeudiw/trust/handler/interface.py
+++ b/pyeudiw/trust/handler/interface.py
@@ -136,9 +136,11 @@ class TrustHandlerInterface:
 
     def is_it_me(self, client_id: str) -> bool:
         """
-        TODO
+        Returns true if, according to this trust framework implementation,
+        the argument client_id refers to the implementation itself as a
+        *member* of the trust framework.
         """
-        return client_id == self.default_client_id
+        return client_id == self.client_id
 
     @property
     def name(self) -> str:
@@ -149,7 +151,7 @@ class TrustHandlerInterface:
         :rtype: str
         """
         return str(self.__class__.__name__)
-    
+
     @property
     def default_client_id(self) -> str:
         """
@@ -158,7 +160,4 @@ class TrustHandlerInterface:
         :returns: The default client id of the trust handler
         :rtype: str
         """
-        # TODO: investiga dove questo viene veramente chiamat
-        # TODO: proposal to rename configured_client_id
-        # breakpoint()
         return self.client_id

--- a/pyeudiw/trust/handler/interface.py
+++ b/pyeudiw/trust/handler/interface.py
@@ -102,11 +102,14 @@ class TrustHandlerInterface:
         """
         raise NotImplementedError
     
-    def get_jwt_header_trust_parameters(self, trust_source: TrustSourceData) -> dict:
+    def extract_jwt_header_trust_parameters(self, trust_source: TrustSourceData) -> dict:
         """
-        Parses a trust source to yield which trust information in the
-        source can be associated to a JWT according to this very own
-        trust evaluation mechanism.
+        Parse a trust source to extract the trust parameters (in the source)
+        that can be used as a JWT header according to what this very own trust
+        evaluation mechanism is capable of understanding.
+
+        Some trust evaluation mechanism is not associated to any JWT header
+        mechanism, in which case an empty dictionary is returned.
         """
         return {}
 

--- a/pyeudiw/trust/handler/interface.py
+++ b/pyeudiw/trust/handler/interface.py
@@ -134,6 +134,12 @@ class TrustHandlerInterface:
         """
         raise NotImplementedError
 
+    def is_it_me(self, client_id: str) -> bool:
+        """
+        TODO
+        """
+        return client_id == self.default_client_id
+
     @property
     def name(self) -> str:
         """
@@ -152,4 +158,7 @@ class TrustHandlerInterface:
         :returns: The default client id of the trust handler
         :rtype: str
         """
+        # TODO: investiga dove questo viene veramente chiamat
+        # TODO: proposal to rename configured_client_id
+        # breakpoint()
         return self.client_id

--- a/pyeudiw/trust/handler/interface.py
+++ b/pyeudiw/trust/handler/interface.py
@@ -102,6 +102,14 @@ class TrustHandlerInterface:
         """
         raise NotImplementedError
     
+    def get_jwt_header_trust_parameters(self, trust_source: TrustSourceData) -> dict:
+        """
+        Parses a trust source to yield which trust information in the
+        source can be associated to a JWT according to this very own
+        trust evaluation mechanism.
+        """
+        return {}
+
     def validate_trust_material(
             self, 
             trust_chain: list[str], 

--- a/pyeudiw/trust/handler/x509.py
+++ b/pyeudiw/trust/handler/x509.py
@@ -134,7 +134,7 @@ class X509Handler(TrustHandlerInterface):
         x5c: list[str], 
         trust_source: TrustSourceData,
     ) -> dict[bool, TrustSourceData]:
-        chain = pem_list_to_der_list(x5c)
+        chain = [base64.b64decode(b64der) for b64der in x5c]
 
         if len(chain) > 1 and not verify_x509_attestation_chain(chain):
             logger.error(f"Invalid x509 certificate chain. Chain validation failed")

--- a/pyeudiw/trust/handler/x509.py
+++ b/pyeudiw/trust/handler/x509.py
@@ -173,7 +173,7 @@ class X509Handler(TrustHandlerInterface):
 
         return True, trust_source
 
-    def get_jwt_header_trust_parameters(self, trust_source: TrustSourceData) -> dict:
+    def extract_jwt_header_trust_parameters(self, trust_source: TrustSourceData) -> dict:
         tp: dict = trust_source.serialize().get(X509Handler._TRUST_TYPE, {})
         if (x5c := tp.get(X509Handler._TRUST_PARAMETER_NAME, None)):
             return {"x5c": x5c}

--- a/pyeudiw/trust/handler/x509.py
+++ b/pyeudiw/trust/handler/x509.py
@@ -1,6 +1,4 @@
-import base64
 import logging
-from ssl import PEM_cert_to_DER_cert
 from typing import Union
 
 from pyeudiw.trust.handler.interface import TrustHandlerInterface
@@ -9,6 +7,8 @@ from pyeudiw.trust.handler.exceptions import InvalidTrustHandlerConfiguration
 from pyeudiw.jwk.parse import parse_pem, parse_x5c_keys, parse_certificate
 from cryptojwt.jwk.jwk import key_from_jwk_dict
 from pyeudiw.x509.verify import (
+    PEM_cert_to_B64DER_cert,
+    to_DER_cert,
     verify_x509_attestation_chain, 
     get_expiry_date_from_x5c, 
     der_list_to_pem_list, 
@@ -36,11 +36,13 @@ class X509Handler(TrustHandlerInterface):
         private_keys: list[dict[str, str]],
         client_id_scheme: str = "x509_san_uri",
         certificate_authorities: dict[str, str] = [],
+        include_issued_jwt_header_param: bool = False,
         **kwargs
     ) -> None:        
         self.client_id = client_id
         self.client_id_scheme = client_id_scheme
         self.certificate_authorities = certificate_authorities
+        self.include_issued_jwt_header_param = include_issued_jwt_header_param
 
         if not relying_party_certificate_chains_by_ca:
             raise InvalidTrustHandlerConfiguration("No x509 certificate chains provided in the configuration")
@@ -70,7 +72,7 @@ class X509Handler(TrustHandlerInterface):
                     break
                 
             if not found_client_id:
-                logger.error(f"Invalid x509 leaf certificate using CA {k}. Unmatching client id ({client_id}); searched among {search_set}, the chain will be removed")
+                logger.error(f"Invalid x509 leaf certificate using CA {k}. Unmatching client id ({client_id}); the chain will be removed")
                 continue
 
             pem_type = get_certificate_type(v[0])
@@ -130,24 +132,30 @@ class X509Handler(TrustHandlerInterface):
         return trust_source
     
     def validate_trust_material(
-        self, 
-        x5c: list[str], 
+        self,
+        x5c: list[str],
         trust_source: TrustSourceData,
     ) -> tuple[bool, TrustSourceData]:
-        chain = [base64.b64decode(b64der) for b64der in x5c]
+        # TODO: qui c'è del lavoro veramente sporco da fare.
+        #  Bisogna
+        #  (1) normalizzare la rappresentazione della chain a DER; per fare questo bisogna fare inferenza se PEM o Base64+DER
+        #  (2) normalizzare il salvatagggio della chain a PEM
+        #  (3) incrociare le dita che MDOC non si sfasci...
+        der_chain = [to_DER_cert(cert) for cert in x5c]
+        pem_chain = der_list_to_pem_list(der_chain)
 
-        if len(chain) > 1 and not verify_x509_attestation_chain(chain):
+        if len(der_chain) > 1 and not verify_x509_attestation_chain(der_chain):
             logger.error(f"Invalid x509 certificate chain. Chain validation failed")
             return False, trust_source
 
-        issuer = get_trust_anchor_from_x5c(chain)
+        issuer = get_trust_anchor_from_x5c(der_chain)
 
         if not issuer:
-            logger.error(f"Invalid x509 certificate chain. Issuer not found")
+            logger.error("Invalid x509 certificate chain. Issuer not found")
             return False, trust_source
         
         if not issuer in self.certificate_authorities:
-            logger.error(f"Invalid x509 certificate chain. Issuer not found in the list of trusted CAs")
+            logger.error("Invalid x509 certificate chain. Issuer not found in the list of trusted CAs")
             return False, trust_source
         
         issuer_pem = self.certificate_authorities[issuer]
@@ -156,19 +164,19 @@ class X509Handler(TrustHandlerInterface):
             issuer_jwk = parse_pem(issuer_pem)
             chain_jwks = parse_x5c_keys(x5c)
         except Exception as e:
-            logger.error(f"Invalid x509 certificate chain. Parsing failed: {e}")
+            logger.error("Invalid x509 certificate chain. Parsing failed: {e}")
             return False, trust_source
 
         if not issuer_jwk.thumbprint == chain_jwks[-1].thumbprint:
-            logger.error(f"Invalid x509 certificate chain. Issuer thumbprint does not match")
+            logger.error("Invalid x509 certificate chain. Issuer thumbprint does not match")
             return False, trust_source
         
         trust_source.add_trust_param(
             "x509",
             TrustEvaluationType(
                 attribute_name=self.get_handled_trust_material_name(),
-                x5c=x5c,
-                expiration_date=get_expiry_date_from_x5c(chain),
+                x5c=pem_chain,
+                expiration_date=get_expiry_date_from_x5c(der_chain),
                 jwks=chain_jwks,
                 trust_handler_name=self.name,
             )
@@ -179,7 +187,7 @@ class X509Handler(TrustHandlerInterface):
     def extract_jwt_header_trust_parameters(self, trust_source: TrustSourceData) -> dict:
         tp: dict = trust_source.serialize().get(X509Handler._TRUST_TYPE, {})
         if (x5c_pem := tp.get(X509Handler._TRUST_PARAMETER_NAME, None)):
-            x5c = [base64.b64encode(PEM_cert_to_DER_cert(pem)).decode() for pem in x5c_pem]
+            x5c = [PEM_cert_to_B64DER_cert(pem) for pem in x5c_pem]
             return {"x5c": x5c}
         return {}
     

--- a/pyeudiw/trust/handler/x509.py
+++ b/pyeudiw/trust/handler/x509.py
@@ -133,7 +133,7 @@ class X509Handler(TrustHandlerInterface):
         self, 
         x5c: list[str], 
         trust_source: TrustSourceData,
-    ) -> dict[bool, TrustSourceData]:
+    ) -> tuple[bool, TrustSourceData]:
         chain = [base64.b64decode(b64der) for b64der in x5c]
 
         if len(chain) > 1 and not verify_x509_attestation_chain(chain):

--- a/pyeudiw/x509/verify.py
+++ b/pyeudiw/x509/verify.py
@@ -1,5 +1,7 @@
+import base64
 import logging
 from datetime import datetime
+import re
 from ssl import DER_cert_to_PEM_cert, PEM_cert_to_DER_cert
 
 import pem
@@ -15,6 +17,8 @@ from cryptography.hazmat.primitives.asymmetric import rsa, ec
 LOG_ERROR = "x509 verification failed: {}"
 
 logger = logging.getLogger(__name__)
+
+_BASE64_RE = re.compile("^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")
 
 
 def _verify_x509_certificate_chain(pems: list[str]):
@@ -89,6 +93,64 @@ def verify_x509_attestation_chain(x5c: list[bytes]) -> bool:
     pems = [DER_cert_to_PEM_cert(cert) for cert in x5c]
 
     return _verify_x509_certificate_chain(pems)
+
+
+def PEM_cert_to_B64DER_cert(cert: str) -> str:
+    """
+    Takes a certificate in ANSII PEM format and returns the base64
+    encoding of the corresponding DER certificate.
+    """
+    return base64.b64encode(PEM_cert_to_DER_cert(cert)).decode()
+
+
+def B64DER_cert_to_PEM_cert(cert: str) -> str:
+    """
+    Takes a certificate Base64 encoded DER and returns the
+    certificate in ANSII PEM format.
+    """
+    return DER_cert_to_PEM_cert(base64.b64decode(cert))
+
+
+def to_DER_cert(cert: str | bytes) -> bytes:
+    """
+    This function takes in a certificate with unknown representation
+    (allegedly, PEM, DER or Base64 encoded DER) and applies some
+    heuristics to convert it to a DER certificate.
+
+    This function should be treated as UNSAFE and inefficient. Do NOT
+    use it unless you do NOT hany prior way to know the actual representation
+    format of a certificate
+    """
+    cert_s = ""
+    if isinstance(cert, bytes):
+        if is_der_format(cert):
+            return cert
+        cert_s = cert.decode()
+    else:
+        cert_s = cert
+
+    if cert_s.startswith("-----BEGIN CERTIFICATE-----"):
+        return PEM_cert_to_DER_cert(cert_s)
+
+    cert_s = cert_s.replace('\n\r', '')
+    if _BASE64_RE.fullmatch(cert_s):
+        return B64DER_cert_to_PEM_cert(cert_s)
+
+    raise ValueError("unable to recognize input [cert] as a ccertifficate")
+
+
+def to_PEM_cert(cer: str | bytes) -> str:
+    """
+    This function takes in a certificate with unknown representation
+    (allegedly, PEM, DER or Base64 encoded DER) and applies some
+    heuristics to convert it to a PEM certificate.
+
+    This function should be treated as UNSAFE and inefficient. Do NOT
+    use it unless you do NOT hany prior way to know the actual representation
+    format of a certificate
+    """
+    raise NotImplementedError("TODO")    
+
 
 def pem_to_pems_list(cert: str) -> list[str]:
     """

--- a/pyeudiw/x509/verify.py
+++ b/pyeudiw/x509/verify.py
@@ -50,25 +50,6 @@ def _verify_x509_certificate_chain(pems: list[str]):
         return False
 
 
-def _check_chain_len(pems: list) -> bool:
-    """
-    Check the x509 certificate chain lenght.
-
-    :param pems: The x509 certificate chain
-    :type pems: list
-
-    :returns: True if the x509 certificate chain lenght is valid else False
-    :rtype: bool
-    """
-    chain_len = len(pems)
-    if chain_len < 2:
-        message = f"invalid chain lenght -> minimum expected 2 found {chain_len}"
-        logging.warning(LOG_ERROR.format(message))
-        return False
-
-    return True
-
-
 def _check_datetime(exp: datetime | None):
     """
     Check the x509 certificate chain expiration date.
@@ -102,7 +83,7 @@ def verify_x509_attestation_chain(x5c: list[bytes]) -> bool:
     """
     exp = get_expiry_date_from_x5c(x5c)
 
-    if not _check_chain_len(x5c) or not _check_datetime(exp):
+    if not _check_datetime(exp):
         return False
     
     pems = [DER_cert_to_PEM_cert(cert) for cert in x5c]
@@ -175,10 +156,6 @@ def verify_x509_anchor(pem_str: str) -> bool:
         return False
 
     pems = pem_to_pems_list(pem_str)
-
-    if not _check_chain_len(pems):
-        logging.error(LOG_ERROR.format("check chain len failed"))
-        return False
 
     return _verify_x509_certificate_chain(pems)
 


### PR DESCRIPTION
This PR include a series of miscelanneous minor improvement and fixes when handling trust parameters.
In particular:
1. Added a new feature where trust headers in issued token must be actively opted-id. See this example configuration https://github.com/Zicchio/eudi-wallet-it-python/blob/d42772758bbb1b445a268e7208ca12aa9e837882/example/satosa/pyeudiw_backend.yaml#L252
2. Added a new feature where trust handler now have full control on how the trust header is represented in the token; this was done to fix #422 and to partially tackle #412
3. Added a new feature for trust handler direct trust to not make http request to client_id that clearly are not URL, this was done to fix #412
4. Added a new feature where direct trust jar was restricted so that only the RP itself recognize itself as JAR issuer (as in openid4vp the rp never interact with others under the guise of JAR issuer)

Commit history is not very clear; as such squashing is recommended