### PR TITLE
Fix broken unit test

### DIFF
--- a/pyeudiw/tests/openid4vp/test_vp_sd_jwt_vc.py
+++ b/pyeudiw/tests/openid4vp/test_vp_sd_jwt_vc.py
@@ -274,5 +274,5 @@ def test_handler_failed_validation():
         )
         assert False, "Validation should have failed."
     except Exception as e:
-        assert str(e) == "Unknown Trust Anchor: 'https://credential_issuer.example.org' is not a recognizable Trust Anchor.", "Incorrect exception message."
+        assert str(e) == "Unknown Trust Anchor: 'https://credential-issuer.example.org' is not a recognizable Trust Anchor.", "Incorrect exception message."
     


### PR DESCRIPTION
This PR fixes a unit test that was accidentally broken during some merge operations and was not naught by CI/CD pipeline due to the fact that the pipeline does not re-run between merges.