### PR TITLE
feat: refactor of jwt key selection for x5c

### DIFF
--- a/pyeudiw/jwk/parse.py
+++ b/pyeudiw/jwk/parse.py
@@ -1,4 +1,3 @@
-import base64
 from cryptojwt.jwk.ec import import_ec_key, ECKey
 from cryptojwt.jwk.rsa import RSAKey, import_rsa_key
 from ssl import DER_cert_to_PEM_cert
@@ -6,6 +5,8 @@ from ssl import DER_cert_to_PEM_cert
 from pyeudiw.jwk import JWK
 from pyeudiw.jwk.exceptions import InvalidJwk
 from typing import Optional
+
+from pyeudiw.x509.verify import B64DER_cert_to_DER_cert
 
 def _parse_rsa_key(pem: str) -> Optional[JWK]:
     try:
@@ -71,7 +72,7 @@ def parse_b64der(b64der: str) -> JWK:
     """
     Parse a (public) key from a Base64 encoded DER certificate.
     """
-    der = base64.b64decode(b64der)
+    der = B64DER_cert_to_DER_cert(b64der)
     return parse_certificate(der)
 
 

--- a/pyeudiw/jwt/helper.py
+++ b/pyeudiw/jwt/helper.py
@@ -87,11 +87,11 @@ def find_self_contained_key(header: dict) -> tuple[set[str], JWK] | None:
         candidate_key: JWK | None = None
         try:
             candidate_key = parse_x5c_keys(header["x5c"])[0]
+            return set(["5xc"]), candidate_key
         except Exception as e:
             logger.debug(
                 f"failed to parse key from x5c chain {header['x5c']}", exc_info=e
             )
-        return set(["5xc"]), candidate_key
     if "jwk" in header:
         candidate_key = JWK(header["jwk"])
         return set(["jwk"]), candidate_key

--- a/pyeudiw/jwt/jws_helper.py
+++ b/pyeudiw/jwt/jws_helper.py
@@ -205,7 +205,7 @@ class JWSHelper(JWHelperInterface):
             return candidate_signing_keys[0]
         return None
 
-    def _select_key_by_kid(self, headers: tuple[dict, dict]) -> dict | None:
+    def _select_key_by_kid(self, headers: tuple[dict[str, Any], dict[str, Any]]) -> dict | None:
         if not headers:
             return None
         if "kid" in headers[0]:
@@ -216,7 +216,7 @@ class JWSHelper(JWHelperInterface):
             return None
         return find_jwk_by_kid([key.to_dict() for key in self.jwks], kid)
 
-    def _select_key_by_x5c(self, headers: tuple[dict, dict]) -> dict | None:
+    def _select_key_by_x5c(self, headers: tuple[dict[str, Any], dict[str, Any]]) -> dict | None:
         if not headers:
             return None
         x5c: list[str] | None = headers[0].get("x5c") or headers[1].get("x5c")

--- a/pyeudiw/jwt/jws_helper.py
+++ b/pyeudiw/jwt/jws_helper.py
@@ -349,7 +349,7 @@ def _validate_key_with_header_kid(key: dict, header: dict) -> None:
         raise Exception(
             f"token header contains a kid {header_kid} that does not match the signing key kid {key_kid}"
         )
-    return None
+    return
 
 
 def _validate_key_with_header_x5c(key: dict, header: dict) -> None:
@@ -363,7 +363,7 @@ def _validate_key_with_header_x5c(key: dict, header: dict) -> None:
     :raises Exception: if the key is not compatible with the header content x5c (if any)
     """
     x5c: list[str] | None = header.get("x5c")
-    if x5c is None:
+    if not x5c:
         return
     leaf_cert: str = x5c[0]
 
@@ -374,13 +374,13 @@ def _validate_key_with_header_x5c(key: dict, header: dict) -> None:
             raise Exception(
                 f"token header containes a chain whose leaf certificate {leaf_cert} does not match the signing key leaf certificate {leaf_x5c_cert}"\
             )
-        return None
+        return
     header_key = parse_b64der(leaf_cert)
     if header_key.thumbprint != JWK(key).thumbprint:
         raise Exception(
             f"public material of the key does not matches the key in the leaf certificate {leaf_cert}"
         )
-    return None
+    return
 
 
 def _validate_key_with_jws_header(key: dict, protected_jws_header: dict, unprotected_jws_header: dict) -> None:

--- a/pyeudiw/openid4vp/presentation_submission/__init__.py
+++ b/pyeudiw/openid4vp/presentation_submission/__init__.py
@@ -179,7 +179,6 @@ class PresentationSubmissionHandler:
         
         for descriptor in validated_submission.descriptor_map:
             handler = self.handlers.get(descriptor.format)
-
             if not handler:
                 raise MissingHandler(f"Handler for format '{descriptor.format}' not found.")
             

--- a/pyeudiw/satosa/default/request_handler.py
+++ b/pyeudiw/satosa/default/request_handler.py
@@ -71,27 +71,7 @@ class RequestHandler(RequestHandlerInterface, BaseLogger):
         trust_params = self.trust_evaluator.get_jwt_header_trust_parameters(issuer=self.client_id)
         _protected_jwt_headers.update(trust_params)
 
-        metadata_key = None
-
-        if "x5c" in _protected_jwt_headers:
-            # TODO: move this logic in the JWS signer...
-            jwk = parse_b64der(_protected_jwt_headers["x5c"][0])
-
-            for key in self.config["metadata_jwks"]:
-                if JWK(key).thumbprint == jwk.thumbprint:
-                    metadata_key = key
-                    break
-            
-            if not metadata_key:
-                return self._handle_500(
-                    context,
-                    "internal error: unable to find the key in the metadata",
-                    ValueError("unable to find the key in the metadata"),
-                )
-        else:
-            metadata_key = self.default_metadata_private_jwk
-
-        helper = JWSHelper(metadata_key)
+        helper = JWSHelper(self.config["metadata_jwks"])
 
         try:
             request_object_jwt = helper.sign(

--- a/pyeudiw/satosa/default/request_handler.py
+++ b/pyeudiw/satosa/default/request_handler.py
@@ -71,7 +71,11 @@ class RequestHandler(RequestHandlerInterface, BaseLogger):
         trust_params = self.trust_evaluator.get_jwt_header_trust_parameters(issuer=self.client_id)
         _protected_jwt_headers.update(trust_params)
 
-        helper = JWSHelper(self.config["metadata_jwks"])
+        if ("x5c" in _protected_jwt_headers) or ("kid" in _protected_jwt_headers):
+            # let helper decide which key best fit the given header, otherise use default hich is the first confgiured key
+            helper = JWSHelper(self.config["metadata_jwks"])
+        else:
+            helper = JWSHelper(self.default_metadata_private_jwk)
 
         try:
             request_object_jwt = helper.sign(

--- a/pyeudiw/tests/jwt/test_helper.py
+++ b/pyeudiw/tests/jwt/test_helper.py
@@ -1,5 +1,12 @@
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptojwt.jwk.ec import ECKey
+
+from pyeudiw.jwk import JWK
 from pyeudiw.jwt.helper import validate_jwt_timestamps_claims
+from pyeudiw.jwt.jws_helper import _validate_key_with_jws_header
 from pyeudiw.tools.utils import iat_now
+import pyeudiw.tests.x509.test_x509 as test_x509
+from pyeudiw.x509.verify import DER_cert_to_B64DER_cert
 
 
 def test_validate_jwt_timestamps_claims_ok():
@@ -71,3 +78,63 @@ def test_test_validate_jwt_timestamps_claims_tolerance_window():
         assert (
             False
         ), f"encountered unexpeted error when validating the lifetime of a token payload with a tolerance window (for exp): {e}"
+
+
+def test_validate_key_with_jws_header_x5c_ok():
+    private_ec_key = ec.generate_private_key(ec.SECP256R1())
+    x509_der_chain = test_x509.gen_chain(leaf_private_key=private_ec_key)
+    x5c = [DER_cert_to_B64DER_cert(der) for der in x509_der_chain]
+    
+    ec_jwk = ECKey()
+    ec_jwk.load_key(private_ec_key)
+    key = ec_jwk.serialize(private=True)
+
+    try:
+        _validate_key_with_jws_header(key, {"x5c": x5c}, {})
+        assert True
+    except Exception as e:
+        assert False, f"unexpected exception when validating header for correct key: {e}"
+
+
+def test_validate_key_with_jws_header_kid_ok():
+    key = JWK().as_dict()
+    kid = "1234567890"
+    key["kid"] = kid
+
+    try:
+        _validate_key_with_jws_header(key, {"kid": kid}, {})
+        assert True
+    except Exception as e:
+        assert False, f"unexpected exception when validating header for correct key: {e}"
+
+
+def test_validate_key_with_jws_header_expect_x5c_fail():
+    private_ec_key = ec.generate_private_key(ec.SECP256R1())
+    x509_der_chain = test_x509.gen_chain(leaf_private_key=private_ec_key)
+    x5c = [DER_cert_to_B64DER_cert(der) for der in x509_der_chain]
+    
+    wrong_ec_key = ec.generate_private_key(ec.SECP256R1())
+    wrong_ec_jwk = ECKey()
+    wrong_ec_jwk.load_key(wrong_ec_key)
+    wrong_key = wrong_ec_jwk.serialize(private=True)
+
+    try:
+        _validate_key_with_jws_header(wrong_key, {"x5c": x5c}, {})
+        assert False, f"should have encountered exception when validating header 'x5c' for wrong key"
+    except Exception as _:
+        assert True
+
+def test_validate_key_with_jws_header_expect_kid_fail():
+    wrong_key = JWK().as_dict()
+    wrong_kid = "1234567890"
+    wrong_key["kid"] = wrong_kid
+    
+    key = JWK().as_dict()
+    kid = "qwertyuiop"
+    key["kid"] = kid
+
+    try:
+        _validate_key_with_jws_header(key, {"kid": "1234567890"}, {})
+        assert False, f"should have encountered exception when validating header 'kid' for wrong key"
+    except Exception as _:
+        assert True

--- a/pyeudiw/tests/satosa/test_backend.py
+++ b/pyeudiw/tests/satosa/test_backend.py
@@ -54,7 +54,7 @@ from pyeudiw.tools.utils import exp_from_now, iat_now
 from pyeudiw.jwt.jwe_helper import JWEHelper
 from pyeudiw.satosa.utils.response import JsonResponse
 from pyeudiw.tests.x509.test_x509 import gen_chain
-from pyeudiw.x509.verify import to_pem_list
+from pyeudiw.x509.verify import PEM_cert_to_B64DER_cert, to_pem_list
 from pyeudiw.jwk.parse import parse_pem
 
 PKEY = {

--- a/pyeudiw/tests/satosa/test_backend.py
+++ b/pyeudiw/tests/satosa/test_backend.py
@@ -192,7 +192,7 @@ class TestOpenID4VPBackend:
         
         if x509:
             additional_headers = {
-                "x5c": self.chain
+                "x5c": [PEM_cert_to_B64DER_cert(pem) for pem in self.chain]
             }
         else:
             additional_headers = {
@@ -622,7 +622,6 @@ class TestOpenID4VPBackend:
         }
         context.request_method = "POST"
         context.http_headers = {"HTTP_CONTENT_TYPE": "application/x-www-form-urlencoded"}
-        
         response_endpoint = self.backend.response_endpoint(context)
         assert response_endpoint.status == "200"
         assert "redirect_uri" in response_endpoint.message

--- a/pyeudiw/x509/verify.py
+++ b/pyeudiw/x509/verify.py
@@ -111,6 +111,14 @@ def B64DER_cert_to_PEM_cert(cert: str) -> str:
     return DER_cert_to_PEM_cert(base64.b64decode(cert))
 
 
+def B64DER_cert_to_DER_cert(cert: str) -> bytes:
+    """
+    Takes a certificate Base64 encoded DER and returns the
+    certificate in DER format.
+    """
+    return base64.b64decode(cert)
+
+
 def to_DER_cert(cert: str | bytes) -> bytes:
     """
     This function takes in a certificate with unknown representation
@@ -134,7 +142,7 @@ def to_DER_cert(cert: str | bytes) -> bytes:
 
     cert_s = cert_s.replace('\n\r', '')
     if _BASE64_RE.fullmatch(cert_s):
-        return B64DER_cert_to_PEM_cert(cert_s)
+        return B64DER_cert_to_DER_cert(cert_s)
 
     raise ValueError("unable to recognize input [cert] as a ccertifficate")
 

--- a/pyeudiw/x509/verify.py
+++ b/pyeudiw/x509/verify.py
@@ -95,6 +95,13 @@ def verify_x509_attestation_chain(x5c: list[bytes]) -> bool:
     return _verify_x509_certificate_chain(pems)
 
 
+def DER_cert_to_B64DER_cert(cert: bytes) -> str:
+    """
+    Encode in Base64 a DER certificate.
+    """
+    return base64.b64encode(cert).decode()
+
+
 def PEM_cert_to_B64DER_cert(cert: str) -> str:
     """
     Takes a certificate in ANSII PEM format and returns the base64

--- a/pyeudiw/x509/verify.py
+++ b/pyeudiw/x509/verify.py
@@ -151,7 +151,7 @@ def to_DER_cert(cert: str | bytes) -> bytes:
     if _BASE64_RE.fullmatch(cert_s):
         return B64DER_cert_to_DER_cert(cert_s)
 
-    raise ValueError("unable to recognize input [cert] as a certificate")
+    raise ValueError("unable to recognize input as a certificate")
 
 
 def to_PEM_cert(cert: str | bytes) -> str:
@@ -185,7 +185,7 @@ def to_PEM_cert(cert: str | bytes) -> str:
     except UnicodeError:
         return DER_cert_to_PEM_cert(cert_b)
 
-    raise ValueError("unable to recognize input [cert] as a certificate")
+    raise ValueError("unable to recognize input as a certificate")
 
 def pem_to_pems_list(cert: str) -> list[str]:
     """


### PR DESCRIPTION
This PR closes #423 and in particular does the following:
1. when signing a jwt with a set of available keys and header x5c is in the token, use a key that matches the x5c header (refactored from `request_handler.py` to `jws_helper.JWSHelper`)
2. when signing a token, a consistency double check is performed to verify that the signing key indeed matches possible "kid" header and "x5c" header (when present in both the key and the header).
3. some minor fixes here and there discovered when working on issue 423.

@peppelinux commits can be squashed