### PR TITLE
[Interoperability] Oauth2 par request

### DIFF
--- a/pyeudiw/satosa/frontends/openid4vci/endpoints/authorization_endpoint.py
+++ b/pyeudiw/satosa/frontends/openid4vci/endpoints/authorization_endpoint.py
@@ -14,7 +14,7 @@ from pyeudiw.satosa.frontends.openid4vci.models.openid4vci_basemodel import (
     ENDPOINT_CTX,
     CLIENT_ID_CTX,
 )
-from pyeudiw.satosa.frontends.openid4vci.storage.engine import OpenId4VciEngine
+from pyeudiw.satosa.frontends.openid4vci.storage.engine import OpenId4VciDBEngineHandler
 from pyeudiw.satosa.frontends.openid4vci.tools.exceptions import InvalidRequestException
 from pyeudiw.satosa.utils.session import get_session_id
 from pyeudiw.satosa.utils.validation import (
@@ -41,7 +41,7 @@ class AuthorizationHandler(VCIBaseEndpoint):
             name (str): The name of the SATOSA module to append to the URL.
         """
         super().__init__(config, internal_attributes, base_url, name)
-        self.db_engine = OpenId4VciEngine(config).db_engine
+        self.db_engine = OpenId4VciDBEngineHandler(config).db_engine
 
     def endpoint(self, context: Context) -> Response:
         """

--- a/pyeudiw/satosa/frontends/openid4vci/endpoints/base_credential_endpoint.py
+++ b/pyeudiw/satosa/frontends/openid4vci/endpoints/base_credential_endpoint.py
@@ -15,7 +15,7 @@ from pyeudiw.jwt.jws_helper import JWSHelper
 from pyeudiw.satosa.frontends.openid4vci.endpoints.vci_base_endpoint import VCIBaseEndpoint, POST_ACCEPTED_METHODS
 from pyeudiw.satosa.frontends.openid4vci.models.credential_endpoint_request import CredentialEndpointRequest
 from pyeudiw.satosa.frontends.openid4vci.models.openid4vci_basemodel import OpenId4VciBaseModel
-from pyeudiw.satosa.frontends.openid4vci.storage.engine import OpenId4VciEngine
+from pyeudiw.satosa.frontends.openid4vci.storage.engine import OpenId4VciDBEngineHandler
 from pyeudiw.satosa.frontends.openid4vci.storage.entity import OpenId4VCIEntity
 from pyeudiw.satosa.frontends.openid4vci.tools.exceptions import InvalidScopeException, InvalidRequestException
 from pyeudiw.satosa.schemas.credential_specification import CredentialSpecificationConfig
@@ -60,7 +60,7 @@ class BaseCredentialEndpoint(ABC, VCIBaseEndpoint):
         self._metadata_jwks = self.config["metadata_jwks"]
         self.jws_helper = JWSHelper(self._metadata_jwks)
         self._mso_mdoc_private_key = from_jwk_to_mso_mdoc_private_key(self._metadata_jwks[0])
-        self.db_engine = OpenId4VciEngine(config).db_engine
+        self.db_engine = OpenId4VciDBEngineHandler(config).db_engine
         _user_credential_engine = UserCredentialEngine(config)
         self._db_user_engine = _user_credential_engine.db_user_storage_engine
         self._db_credential_engine = _user_credential_engine.db_credential_storage_engine

--- a/pyeudiw/satosa/frontends/openid4vci/endpoints/credential_offer_qrcode_endpoint.py
+++ b/pyeudiw/satosa/frontends/openid4vci/endpoints/credential_offer_qrcode_endpoint.py
@@ -5,7 +5,7 @@ from pyeudiw.satosa.backends.openid4vp.schemas.flow import RemoteFlowType
 from pyeudiw.satosa.frontends.openid4vci.endpoints.vci_base_endpoint import GET_ACCEPTED_METHODS, VCIBaseEndpoint
 from pyeudiw.satosa.frontends.openid4vci.models.credential_offer_request import CredentialOfferRequest
 from pyeudiw.satosa.frontends.openid4vci.models.openid4vci_basemodel import CONFIG_CTX
-from pyeudiw.satosa.frontends.openid4vci.storage.engine import OpenId4VciEngine
+from pyeudiw.satosa.frontends.openid4vci.storage.engine import OpenId4VciDBEngineHandler
 from pyeudiw.satosa.frontends.openid4vci.storage.entity import OpenId4VCIEntity
 from pyeudiw.satosa.frontends.openid4vci.tools.exceptions import InvalidRequestException, InvalidScopeException
 from pyeudiw.satosa.utils.html_template import Jinja2TemplateHandler
@@ -40,7 +40,7 @@ class CredentialOfferQrCodeHandler(VCIBaseEndpoint):
         """
         super().__init__(config, internal_attributes, base_url, name)
         self.qrcode_template = Jinja2TemplateHandler(self.qrcode_settings["ui"])
-        self.db_engine = OpenId4VciEngine(config).db_engine
+        self.db_engine = OpenId4VciDBEngineHandler(config).db_engine
 
 
     def endpoint(self, context: Context):

--- a/pyeudiw/satosa/frontends/openid4vci/endpoints/nonce_endpoint.py
+++ b/pyeudiw/satosa/frontends/openid4vci/endpoints/nonce_endpoint.py
@@ -6,7 +6,7 @@ from satosa.response import Response
 from pyeudiw.jwt.jws_helper import JWSHelper
 from pyeudiw.satosa.frontends.openid4vci.endpoints.vci_base_endpoint import VCIBaseEndpoint, POST_ACCEPTED_METHODS
 from pyeudiw.satosa.frontends.openid4vci.models.nonce_response import NonceResponse
-from pyeudiw.satosa.frontends.openid4vci.storage.engine import OpenId4VciEngine
+from pyeudiw.satosa.frontends.openid4vci.storage.engine import OpenId4VciDBEngineHandler
 from pyeudiw.satosa.frontends.openid4vci.tools.exceptions import (
     InvalidRequestException,
     InvalidScopeException
@@ -35,7 +35,7 @@ class NonceHandler(VCIBaseEndpoint):
         """
         super().__init__(config, internal_attributes, base_url, name)
         self.jws_helper = JWSHelper(self.config["metadata_jwks"])
-        self.db_engine = OpenId4VciEngine(config).db_engine
+        self.db_engine = OpenId4VciDBEngineHandler(config).db_engine
 
     def endpoint(self, context: Context) -> Response:
         """

--- a/pyeudiw/satosa/frontends/openid4vci/endpoints/pushed_authorization_request_endpoint.py
+++ b/pyeudiw/satosa/frontends/openid4vci/endpoints/pushed_authorization_request_endpoint.py
@@ -12,7 +12,7 @@ from pyeudiw.satosa.frontends.openid4vci.models.openid4vci_basemodel import (
     CLIENT_ID_CTX,
     ENTITY_ID_CTX
 )
-from pyeudiw.satosa.frontends.openid4vci.models.par_request import ParRequest
+from pyeudiw.satosa.frontends.openid4vci.models.par_request import SignedParRequest, ParRequest
 from pyeudiw.satosa.frontends.openid4vci.models.par_response import ParResponse
 from pyeudiw.satosa.frontends.openid4vci.storage.engine import OpenId4VciEngine
 from pyeudiw.satosa.frontends.openid4vci.storage.entity import OpenId4VCIEntity
@@ -56,6 +56,20 @@ class ParHandler(VCIBaseEndpoint):
             A Response object.
         """
         try:
+            if not context.request_method:
+                self._log_error(
+                    CLASS_NAME,
+                    "invalid request parameters for `par` endpoint, missing request method"
+                )
+                return self._handle_500(context, "invalid request parameters", Exception("invalid request parameters"))
+            
+            if not context.http_headers:
+                self._log_error(
+                    CLASS_NAME,
+                    "invalid request parameters for `par` endpoint, missing HTTP headers"
+                )
+                return self._handle_500(context, "invalid request parameters", Exception("invalid request parameters"))
+
             validate_request_method(context.request_method, POST_ACCEPTED_METHODS)
             validate_content_type(context.http_headers[HTTP_CONTENT_TYPE_HEADER], FORM_URLENCODED)
 
@@ -70,32 +84,7 @@ class ParHandler(VCIBaseEndpoint):
 
             client_id = data.get("client_id", "").strip()
 
-            decoded_request = {}
-
-            if self.signed_par_request == "true" or self.signed_par_request == "both":
-                request = data.get("request", "").strip()
-                try:
-                    payload = self.jws_helper.verify(request)
-
-                    if not isinstance(payload, dict):
-                        self._log_error(
-                            CLASS_NAME,
-                            f"invalid request parameter for `par`, invalid JWS: {request}"
-                        )
-                        return self._handle_400(context, "invalid request parameters")
-
-                    decoded_request.update(payload)
-                except JWSVerificationError:
-                    self._log_error(
-                        CLASS_NAME,
-                        f"invalid request parameter for `par`, invalid JWS: {request}"
-                    )
-                    return self._handle_400(context, "invalid request parameters")
-
-            if self.signed_par_request == "false" or self.signed_par_request == "both":
-                decoded_request.update({k: v for k, v in data.items() if k != "client_id" and k != "request"})
-
-            if not client_id or not decoded_request:
+            if not client_id:
                 self._log_error(
                     CLASS_NAME,
                     f"invalid request parameters for `par` endpoint, missing {'client_id' if not client_id else 'request'}"
@@ -110,20 +99,48 @@ class ParHandler(VCIBaseEndpoint):
                     )
                     return self._handle_400(context, "invalid `client_id` parameters")
 
-            par_request = ParRequest.model_validate(
-                decoded_request, context = {
-                    ENDPOINT_CTX: "par",
-                    CONFIG_CTX: self.config,
-                    CLIENT_ID_CTX: client_id,
-                    ENTITY_ID_CTX: self.entity_id
-                })
+            request = data.get("request", "").strip()
+
+            if request:
+                try:
+                    payload = self.jws_helper.verify(request)
+
+                    if not isinstance(payload, dict):
+                        self._log_error(
+                            CLASS_NAME,
+                            f"invalid request parameter for `par`, invalid JWS: {request}"
+                        )
+                        return self._handle_400(context, "invalid request parameters")
+                    
+                    par_request = SignedParRequest.model_validate(
+                        payload, context={
+                            ENDPOINT_CTX: "par",
+                            CONFIG_CTX: self.config,
+                            CLIENT_ID_CTX: client_id,
+                            ENTITY_ID_CTX: self.entity_id
+                        })
+
+                except JWSVerificationError:
+                    self._log_error(
+                        CLASS_NAME,
+                        f"invalid request parameter for `par`, invalid JWS: {request}"
+                    )
+                    return self._handle_400(context, "invalid request parameters")
+            else:
+                par_request = ParRequest.model_validate(
+                    data, context={
+                        ENDPOINT_CTX: "par",
+                        CONFIG_CTX: self.config,
+                        CLIENT_ID_CTX: client_id,
+                        ENTITY_ID_CTX: self.entity_id
+                    })
             
             random_part = secrets.token_hex(16)
             self._init_db_session(context, random_part, par_request)
 
             return ParResponse.to_created_response(
                 self._to_request_uri(random_part),
-                self.config_utils.get_jwt().par_exp
+                self.config_utils.get_jwt().par_exp or 0
             )
         except (InvalidRequestException, InvalidScopeException, ValidationError) as e:
             return self._handle_400(context, self._handle_validate_request_error(e, "credential"), e)

--- a/pyeudiw/satosa/frontends/openid4vci/endpoints/pushed_authorization_request_endpoint.py
+++ b/pyeudiw/satosa/frontends/openid4vci/endpoints/pushed_authorization_request_endpoint.py
@@ -14,7 +14,7 @@ from pyeudiw.satosa.frontends.openid4vci.models.openid4vci_basemodel import (
 )
 from pyeudiw.satosa.frontends.openid4vci.models.par_request import SignedParRequest, ParRequest
 from pyeudiw.satosa.frontends.openid4vci.models.par_response import ParResponse
-from pyeudiw.satosa.frontends.openid4vci.storage.engine import OpenId4VciEngine
+from pyeudiw.satosa.frontends.openid4vci.storage.engine import OpenId4VciDBEngineHandler
 from pyeudiw.satosa.frontends.openid4vci.storage.entity import OpenId4VCIEntity
 from pyeudiw.satosa.frontends.openid4vci.tools.exceptions import (
     InvalidRequestException,
@@ -45,7 +45,7 @@ class ParHandler(VCIBaseEndpoint):
         """
         super().__init__(config, internal_attributes, base_url, name)
         self.jws_helper = JWSHelper(self.config["metadata_jwks"])
-        self.db_engine = OpenId4VciEngine(config).db_engine
+        self.db_engine = OpenId4VciDBEngineHandler(config).db_engine
 
     def endpoint(self, context: Context):
         """

--- a/pyeudiw/satosa/frontends/openid4vci/endpoints/pushed_authorization_request_endpoint.py
+++ b/pyeudiw/satosa/frontends/openid4vci/endpoints/pushed_authorization_request_endpoint.py
@@ -101,7 +101,7 @@ class ParHandler(VCIBaseEndpoint):
 
             request = data.get("request", "").strip()
 
-            if request:
+            if request and (self.signed_par_request == "true" or self.signed_par_request == "both"):
                 try:
                     payload = self.jws_helper.verify(request)
 
@@ -126,7 +126,7 @@ class ParHandler(VCIBaseEndpoint):
                         f"invalid request parameter for `par`, invalid JWS: {request}"
                     )
                     return self._handle_400(context, "invalid request parameters")
-            else:
+            elif (self.signed_par_request == "false" or self.signed_par_request == "both"):
                 par_request = ParRequest.model_validate(
                     data, context={
                         ENDPOINT_CTX: "par",
@@ -134,7 +134,13 @@ class ParHandler(VCIBaseEndpoint):
                         CLIENT_ID_CTX: client_id,
                         ENTITY_ID_CTX: self.entity_id
                     })
-            
+            else:
+                self._log_error(
+                    CLASS_NAME,
+                    "invalid request parameters for `par` endpoint, missing request or signed request"
+                )
+                return self._handle_400(context, "invalid request parameters")
+
             random_part = secrets.token_hex(16)
             self._init_db_session(context, random_part, par_request)
 

--- a/pyeudiw/satosa/frontends/openid4vci/endpoints/pushed_authorization_request_endpoint.py
+++ b/pyeudiw/satosa/frontends/openid4vci/endpoints/pushed_authorization_request_endpoint.py
@@ -163,7 +163,7 @@ class ParHandler(VCIBaseEndpoint):
         """
         entity = OpenId4VCIEntity.new_entity(context, request_uri_part, par_request)
         try:
-            self.db_engine.init_session(entity)
+            self.db_engine.init_session(entity.session_id, entity.state, entity.remote_flow_typ)
         except Exception as e500:
             self._log_critical(
                 e500.__class__.__name__,

--- a/pyeudiw/satosa/frontends/openid4vci/endpoints/pushed_authorization_request_endpoint.py
+++ b/pyeudiw/satosa/frontends/openid4vci/endpoints/pushed_authorization_request_endpoint.py
@@ -151,13 +151,13 @@ class ParHandler(VCIBaseEndpoint):
             )
             return self._handle_500(context, "error during invoke par endpoint", e)
 
-    def _init_db_session(self, context: Context, request_uri_part: str, par_request: ParRequest):
+    def _init_db_session(self, context: Context, request_uri_part: str, par_request: ParRequest | SignedParRequest):
         """
         Initialize a new DB session for a credential issuance flow.
         Args:
             context (Context): The SATOSA context.
             request_uri_part (str): The generated URI part.
-            par_request (ParRequest): The validated request data.
+            par_request (ParRequest | SignedParRequest): The validated request data.
         Raises:
             Exception: If the DB operation fails.
         """

--- a/pyeudiw/satosa/frontends/openid4vci/endpoints/token_endpoint.py
+++ b/pyeudiw/satosa/frontends/openid4vci/endpoints/token_endpoint.py
@@ -22,7 +22,7 @@ from pyeudiw.satosa.frontends.openid4vci.models.token_request import (
     SCOPE_CTX
 )
 from pyeudiw.satosa.frontends.openid4vci.models.token_response import TokenResponse
-from pyeudiw.satosa.frontends.openid4vci.storage.engine import OpenId4VciEngine
+from pyeudiw.satosa.frontends.openid4vci.storage.engine import OpenId4VciDBEngineHandler
 from pyeudiw.satosa.frontends.openid4vci.storage.entity import OpenId4VCIEntity
 from pyeudiw.satosa.frontends.openid4vci.tools.exceptions import (
     InvalidRequestException,
@@ -59,7 +59,7 @@ class TokenHandler(VCIBaseEndpoint):
         """
         super().__init__(config, internal_attributes, base_url, name)
         self.jws_helper = JWSHelper(self.config["metadata_jwks"])
-        self.db_engine = OpenId4VciEngine(config).db_engine
+        self.db_engine = OpenId4VciDBEngineHandler(config).db_engine
 
     def endpoint(self, context: Context):
         """

--- a/pyeudiw/satosa/frontends/openid4vci/models/par_request.py
+++ b/pyeudiw/satosa/frontends/openid4vci/models/par_request.py
@@ -18,6 +18,104 @@ from pyeudiw.tools.date import is_valid_unix_timestamp
 logger = logging.getLogger(__name__)
 
 class ParRequest(OpenId4VciBaseModel):
+    state: str = None
+    scope: str = None
+    client_id: str = None
+    redirect_uri: str = None
+    response_type: str = None
+    code_challenge: str = None
+    code_challenge_method: str = None
+    authorization_details: List[AuthorizationDetail] = None
+
+    @model_validator(mode='after')
+    def check_par_request(self) -> "ParRequest":
+      config = self.get_config_utils().get_oauth_authorization_server()
+      req_client_id = self.get_ctx(CLIENT_ID_CTX)
+      endpoint = self.get_ctx(ENDPOINT_CTX)
+      self.validate_state(endpoint)
+      self.validate_client_id(req_client_id, endpoint)
+
+      if config.response_types_supported:
+          self.validate_response_type(config.response_types_supported, endpoint)
+      
+      self.validate_code_challenge(endpoint)
+
+      if config.code_challenge_methods_supported:
+        self.validate_code_challenge_method(config.code_challenge_methods_supported, endpoint)
+
+      if config.scopes_supported:
+        self.validate_scope(config.scopes_supported, endpoint)
+      
+      self.validate_authorization_details(endpoint)
+      if not self.scope and (not self.authorization_details or len(self.authorization_details) == 0):
+        raise InvalidRequestException("Missing `scope` and `authorization_details` in `par` endpoint")
+
+      self.validate_redirect_uri(endpoint)
+      return self
+
+    def validate_redirect_uri(self, endpoint: str):
+      self.redirect_uri = self.strip(self.redirect_uri)
+      self.check_missing_parameter(self.redirect_uri, "redirect_uri", endpoint)
+
+      try:
+        parsed_redirect_uri = urlparse(self.redirect_uri)
+        if not parsed_redirect_uri.scheme or not parsed_redirect_uri.netloc or not parsed_redirect_uri.path:
+          logger.error(f"invalid redirect_uri value '{self.redirect_uri}' in `{endpoint}` endpoint")
+          raise InvalidRequestException("invalid `redirect_uri` parameter")
+      except Exception as e:
+        logger.error(f"invalid redirect_uri value '{self.redirect_uri}' in `{endpoint}` endpoint: {e}")
+        raise InvalidRequestException("invalid `redirect_uri` parameter")
+
+    def validate_authorization_details(self, endpoint: str):
+      if self.authorization_details:
+        for ad in self.authorization_details:
+          AuthorizationDetail.model_validate(ad, context = {
+            CONFIG_CTX: self.get_config(),
+            ENDPOINT_CTX: endpoint
+          })
+
+    def validate_state(self, endpoint: str):
+      self.state = self.strip(self.state)
+      self.check_missing_parameter(self.state, "state", endpoint)
+      if len(self.state) < 32 or not self.state.isalnum():
+        logger.error(f"invalid state {self.state} in `{endpoint}` endpoint")
+        raise InvalidRequestException("invalid `state` parameter")
+      
+    def validate_client_id(self, req_client_id: str, endpoint: str):
+      self.client_id = self.strip(self.client_id)
+      self.check_missing_parameter(self.client_id, "client_id", endpoint)
+      if self.client_id != req_client_id:
+        logger.error(f"invalid request client_id {self.client_id} in `{endpoint}` endpoint")
+        raise InvalidRequestException("invalid `client_id` parameter")
+      
+    def validate_response_type(self, response_types_supported: list[str], endpoint: str):
+      self.response_type = self.strip(self.response_type)
+      self.check_missing_parameter(self.response_type, "response_type", endpoint)
+      if self.response_type not in response_types_supported:
+        logger.error(f"invalid response type {self.response_type} in `{endpoint}` endpoint")
+        raise InvalidRequestException("invalid `response_type` parameter")
+      
+    def validate_code_challenge(self, endpoint: str):
+      self.code_challenge = self.strip(self.code_challenge)
+      self.check_missing_parameter(self.code_challenge, "code_challenge", endpoint)
+
+    def validate_code_challenge_method(self, code_challenge_methods_supported: list[str], endpoint: str):
+      self.code_challenge_method = self.strip(self.code_challenge_method)
+      self.check_missing_parameter(self.code_challenge_method, "code_challenge_method", endpoint)
+      if self.code_challenge_method not in code_challenge_methods_supported:
+        logger.error(f"invalid code_challenge_method {self.code_challenge_method} in `{endpoint}` endpoint")
+        raise InvalidRequestException("invalid `code_challenge_method` parameter")
+      
+    def validate_scope(self, scopes_supported: list[str], endpoint: str):
+      self.scope = self.strip(self.scope)
+      if self.scope:
+        scopes = self.scope.split(" ")
+        for s in scopes:
+          if s not in scopes_supported:
+            logger.error(f"invalid scope value '{s}' in `{endpoint}` endpoint")
+            raise InvalidRequestException("invalid `scope` parameter")
+
+class SignedParRequest(OpenId4VciBaseModel):
   iss: str = None
   aud: str = None
   exp: int = None

--- a/pyeudiw/satosa/frontends/openid4vci/openid4vci.py
+++ b/pyeudiw/satosa/frontends/openid4vci/openid4vci.py
@@ -9,7 +9,7 @@ from satosa.frontends.base import FrontendModule
 from satosa.internal import InternalData
 from satosa.response import Response
 
-from pyeudiw.satosa.frontends.openid4vci.storage.engine import OpenId4VciEngine
+from pyeudiw.satosa.frontends.openid4vci.storage.engine import OpenId4VciDBEngineHandler
 from pyeudiw.satosa.utils.session import get_session_id
 from pyeudiw.tools.endpoints_loader import EndpointsLoader
 
@@ -32,7 +32,7 @@ class OpenID4VCIFrontend(FrontendModule):
     self.config = config
     self.base_url = base_url
     self.name = name
-    self.db_engine = OpenId4VciEngine(config).db_engine
+    self.db_engine = OpenId4VciDBEngineHandler(config).db_engine
 
   def register_endpoints(self, backend_names, **kwargs):
     """

--- a/pyeudiw/satosa/frontends/openid4vci/openid4vci.py
+++ b/pyeudiw/satosa/frontends/openid4vci/openid4vci.py
@@ -50,4 +50,5 @@ class OpenID4VCIFrontend(FrontendModule):
     return url_map
 
   def handle_authn_response(self, context: Context, internal_resp: InternalData) -> None:
+    #TODO: never reached, needs to be integrated
     self.db_engine.update_attributes_by_session_id(get_session_id(context), internal_resp.attributes)

--- a/pyeudiw/satosa/frontends/openid4vci/storage/engine.py
+++ b/pyeudiw/satosa/frontends/openid4vci/storage/engine.py
@@ -1,5 +1,7 @@
-from pyeudiw.satosa.frontends.openid4vci.storage.openid4vci_storage import OpenId4VciStorage
+import logging
 from pyeudiw.storage.db_engine import DBEngine
+
+logger = logging.getLogger(__name__)
 
 class OpenId4VciDBEngineHandler:
     """
@@ -35,7 +37,7 @@ class OpenId4VciDBEngineHandler:
             self._db_engine.is_connected
         except Exception as e:
             if getattr(self, "_db_engine", None):
-                self._log_error(
+                logger.error(
                     e.__class__.__name__,
                     f"OpenID4VCI db storage handling, connection check silently fails and get restored: {e}"
                 )

--- a/pyeudiw/satosa/frontends/openid4vci/storage/engine.py
+++ b/pyeudiw/satosa/frontends/openid4vci/storage/engine.py
@@ -1,7 +1,7 @@
 from pyeudiw.satosa.frontends.openid4vci.storage.openid4vci_storage import OpenId4VciStorage
 from pyeudiw.storage.db_engine import DBEngine
 
-class OpenId4VciEngine:
+class OpenId4VciDBEngineHandler:
     """
         Engine for managing OpenID4VCI storage operations.
 

--- a/pyeudiw/satosa/frontends/openid4vci/storage/engine.py
+++ b/pyeudiw/satosa/frontends/openid4vci/storage/engine.py
@@ -22,7 +22,7 @@ class OpenId4VciDBEngineHandler:
         self._db_engine = None
 
     @property
-    def db_engine(self) -> OpenId4VciStorage:
+    def db_engine(self) -> DBEngine:
         """
         Lazily initialized access to MongoDB storage engine.
         Returns:

--- a/pyeudiw/satosa/frontends/openid4vci/storage/entity.py
+++ b/pyeudiw/satosa/frontends/openid4vci/storage/entity.py
@@ -23,7 +23,7 @@ class OpenId4VCIEntity(BaseModel):
   redirect_uri: str
   authorization_details: Optional[List[AuthorizationDetail]] = None
   scope: Optional[str] = None
-  c_nonce: str = None
+  c_nonce: Optional[str] = None
   finalized: bool = False
   attributes: Optional[dict] = None
 

--- a/pyeudiw/satosa/frontends/openid4vci/storage/entity.py
+++ b/pyeudiw/satosa/frontends/openid4vci/storage/entity.py
@@ -7,7 +7,7 @@ from satosa.context import Context
 
 from pyeudiw.satosa.backends.openid4vp.utils import detect_flow_typ
 from pyeudiw.satosa.frontends.openid4vci.models.auhtorization_detail import AuthorizationDetail
-from pyeudiw.satosa.frontends.openid4vci.models.par_request import ParRequest
+from pyeudiw.satosa.frontends.openid4vci.models.par_request import ParRequest, SignedParRequest
 
 
 class OpenId4VCIEntity(BaseModel):
@@ -28,6 +28,7 @@ class OpenId4VCIEntity(BaseModel):
   attributes: Optional[dict] = None
 
   @staticmethod
+  def new_entity(context: Context, request_uri_part: str, par_request: ParRequest | SignedParRequest) -> "OpenId4VCIEntity":
       if not context.state:
           raise ValueError("Invalid context state")
 

--- a/pyeudiw/satosa/frontends/openid4vci/storage/entity.py
+++ b/pyeudiw/satosa/frontends/openid4vci/storage/entity.py
@@ -28,7 +28,9 @@ class OpenId4VCIEntity(BaseModel):
   attributes: Optional[dict] = None
 
   @staticmethod
-  def new_entity(context: Context, request_uri_part: str, par_request: ParRequest):
+      if not context.state:
+          raise ValueError("Invalid context state")
+
       return OpenId4VCIEntity(
           request_uri_part=request_uri_part,
           state=par_request.state,

--- a/pyeudiw/satosa/frontends/openid4vci/storage/openid4vci_storage.py
+++ b/pyeudiw/satosa/frontends/openid4vci/storage/openid4vci_storage.py
@@ -3,6 +3,8 @@ from pymongo.results import UpdateResult
 from pyeudiw.satosa.frontends.openid4vci.storage.entity import OpenId4VCIEntity
 from pyeudiw.storage.mongo_storage import MongoStorage
 
+#TODO: This class is never used. The code inside must be integrated and standardized in the DBEngine class and the MongoStorage class.
+#       It is kept here for reference and future integration.
 
 class OpenId4VciStorage(MongoStorage):
     """

--- a/pyeudiw/tests/satosa/frontends/openid4vci/models/test_par_request.py
+++ b/pyeudiw/tests/satosa/frontends/openid4vci/models/test_par_request.py
@@ -12,7 +12,7 @@ from pyeudiw.satosa.frontends.openid4vci.models.openid4vci_basemodel import (
     ENDPOINT_CTX,
     ENTITY_ID_CTX
 )
-from pyeudiw.satosa.frontends.openid4vci.models.par_request import ParRequest
+from pyeudiw.satosa.frontends.openid4vci.models.par_request import SignedParRequest
 from pyeudiw.satosa.frontends.openid4vci.tools.exceptions import InvalidRequestException
 from pyeudiw.tests.satosa.frontends.openid4vci.mock_openid4vci import MOCK_PYEUDIW_FRONTEND_CONFIG
 
@@ -32,7 +32,7 @@ def test_empty_or_missing_iss(value):
         payload["iss"] = value
 
     with pytest.raises(InvalidRequestException, match="missing `iss` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 @pytest.mark.parametrize("value", ["test_iss_0", "  test_iss_1", "test_iss_2", " test_iss_3 "])
 def test_invalid_iss(value):
@@ -41,7 +41,7 @@ def test_invalid_iss(value):
     }
 
     with pytest.raises(InvalidRequestException, match="invalid `iss` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 @pytest.mark.parametrize("value", ["", "  ", None])
 def test_empty_or_missing_aud(value):
@@ -52,7 +52,7 @@ def test_empty_or_missing_aud(value):
         payload["aud"] = value
 
     with pytest.raises(InvalidRequestException, match="missing `aud` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 @pytest.mark.parametrize("value", ["test_0", "  test_1", "test_2", " test_3 "])
 def test_invalid_aud(value):
@@ -62,7 +62,7 @@ def test_invalid_aud(value):
     }
 
     with pytest.raises(InvalidRequestException, match="invalid `aud` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 
 @pytest.mark.parametrize("value", ["", "  ", None])
@@ -75,7 +75,7 @@ def test_empty_or_missing_state(value):
         payload["state"] = value
 
     with pytest.raises(InvalidRequestException, match="missing `state` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 @pytest.mark.parametrize("value", [
     "short123", #too short
@@ -89,7 +89,7 @@ def test_invalid_state(value):
     }
 
     with pytest.raises(InvalidRequestException, match="invalid `state` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 @pytest.mark.parametrize("value", ["", "  ", None])
 def test_empty_or_missing_client_id(value):
@@ -102,7 +102,7 @@ def test_empty_or_missing_client_id(value):
         payload["client_id"] = value
 
     with pytest.raises(InvalidRequestException, match="missing `client_id` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 @pytest.mark.parametrize("value", ["test_0", "  test_1", "test_2", " test_3 "])
 def test_invalid_client_id(value):
@@ -113,7 +113,7 @@ def test_invalid_client_id(value):
         "client_id": value
     }
     with pytest.raises(InvalidRequestException, match="invalid `client_id` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 
 @pytest.mark.parametrize("value", [0, None])
@@ -128,7 +128,7 @@ def test_invalid_exp(value):
         payload["exp"] = value
 
     with pytest.raises(InvalidRequestException, match="invalid `exp` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 @pytest.mark.parametrize("value", [123, None])
 def test_invalid_iat(value):
@@ -143,7 +143,7 @@ def test_invalid_iat(value):
         payload["iat"] = value
 
     with pytest.raises(InvalidRequestException, match="invalid `iat` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 def test_expired_token():
     now = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
@@ -157,7 +157,7 @@ def test_expired_token():
     }
 
     with pytest.raises(InvalidRequestException, match="expired token"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 @pytest.mark.parametrize("value", ["", "  ", None])
 def test_empty_or_missing_response_type(value):
@@ -174,7 +174,7 @@ def test_empty_or_missing_response_type(value):
         payload["response_type"] = value
 
     with pytest.raises(InvalidRequestException, match="missing `response_type` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 
 @pytest.mark.parametrize("value", ["test_0", "  test_1", "test_2", " test_3 "])
@@ -190,7 +190,7 @@ def test_invalid_client_id(value):
         "response_type": value
     }
     with pytest.raises(InvalidRequestException, match="invalid `response_type` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 @pytest.mark.parametrize("value", ["", "  ", None])
 def test_empty_or_missing_response_mode(value):
@@ -208,7 +208,7 @@ def test_empty_or_missing_response_mode(value):
         payload["response_mode"] = value
 
     with pytest.raises(InvalidRequestException, match="missing `response_mode` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 @pytest.mark.parametrize("value", ["test_0", "  test_1", "test_2", " test_3 "])
 def test_invalid_response_mode(value):
@@ -224,7 +224,7 @@ def test_invalid_response_mode(value):
         "response_mode": value
     }
     with pytest.raises(InvalidRequestException, match="invalid `response_mode` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 @pytest.mark.parametrize("value", ["", "  ", None])
 def test_empty_or_missing_code_challenge(value):
@@ -243,7 +243,7 @@ def test_empty_or_missing_code_challenge(value):
         payload["code_challenge"] = value
 
     with pytest.raises(InvalidRequestException, match="missing `code_challenge` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 @pytest.mark.parametrize("value", ["", "  ", None])
 def test_empty_or_missing_code_challenge_method(value):
@@ -263,7 +263,7 @@ def test_empty_or_missing_code_challenge_method(value):
         payload["code_challenge_method"] = value
 
     with pytest.raises(InvalidRequestException, match="missing `code_challenge_method` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 @pytest.mark.parametrize("value", ["test_0", "  test_1", "test_2", " test_3 "])
 def test_invalid_code_challenge_method(value):
@@ -282,7 +282,7 @@ def test_invalid_code_challenge_method(value):
     }
 
     with pytest.raises(InvalidRequestException, match="invalid `code_challenge_method` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 @pytest.mark.parametrize("value", ["test_0", "  test_1", "test_2", " test_3 ", "scope1, pippo"])
 def test_invalid_code_challenge_method(value):
@@ -302,7 +302,7 @@ def test_invalid_code_challenge_method(value):
     }
 
     with pytest.raises(InvalidRequestException, match="invalid `scope` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 
 @pytest.mark.parametrize("authorization_details, scope", [
@@ -336,7 +336,7 @@ def test_empty_or_missing_authorization_details(authorization_details, scope):
         payload["scope"] = scope
 
     with pytest.raises(InvalidRequestException, match="Missing `scope` and `authorization_details` in `par` endpoint"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 @pytest.mark.parametrize("value", ["", "  ", None])
 def test_missing_authorization_details_type(value):
@@ -360,7 +360,7 @@ def test_missing_authorization_details_type(value):
     }
 
     with pytest.raises(InvalidRequestException, match="missing `authorization_details.type` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 @pytest.mark.parametrize("value", ["test_0", "  test_1", "test_2", " test_3 "])
 def test_invalid_authorization_details_type(value):
@@ -384,7 +384,7 @@ def test_invalid_authorization_details_type(value):
     }
 
     with pytest.raises(InvalidRequestException, match="invalid `authorization_details.type` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 @pytest.mark.parametrize("value", ["", "  ", None])
 def test_missing_authorization_credential_configuration_id(value):
@@ -410,7 +410,7 @@ def test_missing_authorization_credential_configuration_id(value):
     }
 
     with pytest.raises(InvalidRequestException, match="missing `authorization_details.credential_configuration_id` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 @pytest.mark.parametrize("value", ["test_0", "  test_1", "test_2", " test_3 "])
 def test_invalid_authorization_details_credential_configuration_id(value):
@@ -435,7 +435,7 @@ def test_invalid_authorization_details_credential_configuration_id(value):
     }
 
     with pytest.raises(InvalidRequestException, match="invalid `authorization_details.credential_configuration_id` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 @pytest.mark.parametrize("value", ["", "  ", None])
 def test_missing_redirect_uri(value):
@@ -462,7 +462,7 @@ def test_missing_redirect_uri(value):
         payload["redirect_uri"] = value
 
     with pytest.raises(InvalidRequestException, match="missing `redirect_uri` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 
 @pytest.mark.parametrize("value", [
@@ -495,7 +495,7 @@ def test_invalid_redirect_uri(value):
     }
 
     with pytest.raises(InvalidRequestException, match="invalid `redirect_uri` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 @pytest.mark.parametrize("value", ["", "  ", None])
 def test_missing_jti(value):
@@ -523,7 +523,7 @@ def test_missing_jti(value):
         payload["jti"] = value
 
     with pytest.raises(InvalidRequestException, match="missing `jti` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())
 
 
 @pytest.mark.parametrize("value", ["test_0", "  test_1", "test_2", " test_3 ", "client-123 ", "client-123"])
@@ -551,4 +551,4 @@ def test_invalid_jti(value):
     }
 
     with pytest.raises(InvalidRequestException, match="invalid `jti` parameter"):
-        ParRequest.model_validate(payload, context=get_valid_context())
+        SignedParRequest.model_validate(payload, context=get_valid_context())

--- a/pyeudiw/tools/date.py
+++ b/pyeudiw/tools/date.py
@@ -1,6 +1,7 @@
 import datetime
+from typing import Optional, Any
 
-def is_valid_unix_timestamp(ts: int, range=60) -> bool:
+def is_valid_unix_timestamp(ts: Any, range: Optional[int]=60) -> bool:
   """
   Checks if the given value is a valid UNIX timestamp (in seconds).
 


### PR DESCRIPTION
This PR removes the work done in #484 in favor on an approach more dynamic.
As described in in the PAR [section in Openid4vci](https://openid.github.io/OpenID4VCI/openid-4-verifiable-credential-issuance-wg-draft.html#name-pushed-authorization-reques) in the body of the request are included only the fields are: scope, response_type, client_id, code_challenge, code_challenge_method, state, redirect_uri.
For this reason it can't be mapped 1:1 with an IT Wallet request because the signed jwt has more fields that are validated like exp or jti.
To enable the interoperability between IT Wallet and the classical Openid4VCI the PAR endpoints checks that the body contains a request parameter.
If present, and the signed_par_request is true or both, it validate and decode the body of JWT and does all extra necessary validation on the fields, omitting the wallet attestation or the dpop validations if the relative fields in security section in the config are set to false, if not present it will be validated as a classical Openid4VCI request. 