### PR TITLE
metadata: auto-build URL from path specified in metadata config

### DIFF
--- a/pyeudiw/satosa/frontends/openid4vci/endpoints/credential_issuer_metadata_endpoint.py
+++ b/pyeudiw/satosa/frontends/openid4vci/endpoints/credential_issuer_metadata_endpoint.py
@@ -43,6 +43,9 @@ class CredentialIssuerMetadataHandler(VCIBaseEndpoint):
         """Returns the entity configuration as a dictionary."""
 
         ec_payload = self.metadata.get("openid_credential_issuer", {})
+        for k in ec_payload: #automatically add <base_url>/<name> if only path was specified in config
+            if "endpoint" in k and "http" not in ec_payload[k]:
+                ec_payload[k] = self._backend_url + ec_payload[k]
         return ec_payload
 
     def endpoint(self, context: Context) -> JsonResponse:

--- a/pyeudiw/satosa/frontends/openid4vci/endpoints/metadata_endpoint.py
+++ b/pyeudiw/satosa/frontends/openid4vci/endpoints/metadata_endpoint.py
@@ -66,6 +66,10 @@ class MetadataHandler(VCIBaseEndpoint):
                 cred_issuer["jwks"] = {
                     "keys": [JWK(k).as_public_dict() for k in cred_issuer["jwks"]]
                 }
+
+            for k in cred_issuer: #automatically add <base_url>/<name> if only path was specified in config
+                if "endpoint" in k and isinstance(cred_issuer[k], str) and "http" not in cred_issuer[k]:
+                    cred_issuer[k] = self._backend_url + cred_issuer[k]
         return metadata
 
     @property


### PR DESCRIPTION
For endpoints exposed in the EC, support has now been added to be able to specify only the path rather than the full URL in the frontend configuration. A URL is automatically constructed using the internal variables of the SATOSA frontend and exposed in /openid-federation and /openid-credential-issuer.

### Example:

**config openid4vci_frontend.yaml:**

```
...
metadata:
    openid_credential_issuer
        credential_endpoint: /credential
...

```

**openid-federation:**
```
...
 "metadata": {
        "openid_credential_issuer": "https://iam-proxy-italia.example.org/OpenID4VCI/credential"
}
...
```